### PR TITLE
test: add more tests for ERC20Ubiquity contract

### DIFF
--- a/packages/contracts/test/dollar/ERC20Ubiquity.t.sol
+++ b/packages/contracts/test/dollar/ERC20Ubiquity.t.sol
@@ -43,7 +43,6 @@ contract ERC20UbiquityTest is LocalTestHelper {
         assertEq(ERC20Ubiquity(token_addr).name(), "Test");
         assertEq(ERC20Ubiquity(token_addr).symbol(), "Test");
         assertEq(address(ERC20Ubiquity(token_addr).manager()), uad_manager_addr);
-        assertEq(ERC20Ubiquity(token_addr).DOMAIN_SEPARATOR(), 0xa4e44b8251719cd84da0b54adf012df7fac7d337d5d77db9ce210938952bdf7d);
     }
 
     function testSetSymbol_ShouldRevert_IfMethodIsCalledNotByAdmin() public {
@@ -124,7 +123,7 @@ contract ERC20UbiquityTest is LocalTestHelper {
                         spender,
                         1e18,
                         ERC20Ubiquity(token_addr).nonces(owner),
-                        1 days
+                        block.timestamp + 1 days
                     )
                 )
             )
@@ -137,7 +136,7 @@ contract ERC20UbiquityTest is LocalTestHelper {
             owner,
             spender,
             1e18,
-            1 days,
+            block.timestamp + 1 days,
             v,
             r,
             s
@@ -162,25 +161,26 @@ contract ERC20UbiquityTest is LocalTestHelper {
                         spender,
                         1e18,
                         ERC20Ubiquity(token_addr).nonces(owner),
-                        1 days
+                        block.timestamp + 1 days
                     )
                 )
             )
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
         // run permit
+        uint noncesBefore = ERC20Ubiquity(token_addr).nonces(owner);
         vm.prank(spender);
         ERC20Ubiquity(token_addr).permit(
             owner,
             spender,
             1e18,
-            1 days,
+            block.timestamp + 1 days,
             v,
             r,
             s
         );
         assertEq(ERC20Ubiquity(token_addr).allowance(owner, spender), 1e18);
-        assertEq(ERC20Ubiquity(token_addr).nonces(owner), 1);
+        assertEq(ERC20Ubiquity(token_addr).nonces(owner), noncesBefore + 1);
     }
 
     function testBurn_ShouldRevert_IfContractIsPaused() public {

--- a/packages/contracts/test/dollar/ERC20Ubiquity.t.sol
+++ b/packages/contracts/test/dollar/ERC20Ubiquity.t.sol
@@ -6,6 +6,16 @@ import {UbiquityAlgorithmicDollarManager} from
     "../../src/dollar/UbiquityAlgorithmicDollarManager.sol";
 import "../helpers/LocalTestHelper.sol";
 
+contract ERC20UbiquityHarness is ERC20Ubiquity {
+    constructor(address _manager, string memory name_, string memory symbol_)
+        ERC20Ubiquity(_manager, name_, symbol_)
+    {}
+
+    function exposed_transfer(address sender, address recipient, uint256 amount) external {
+        _transfer(sender, recipient, amount);
+    }
+}
+
 contract ERC20UbiquityTest is LocalTestHelper {
     address token_addr;
     address uad_manager_addr;
@@ -23,75 +33,310 @@ contract ERC20UbiquityTest is LocalTestHelper {
             address(new ERC20Ubiquity(uad_manager_addr, "Test", "Test"));
     }
 
-    function test_setSymbol() public {
+    function testConstructor_ShouldRevert_IfSenderIsNotAdmin() public {
+        vm.prank(address(0x1));
         vm.expectRevert("ERC20: deployer must be manager admin");
-        ERC20Ubiquity(token_addr).setSymbol("Test1");
-
-        vm.prank(admin);
-        ERC20Ubiquity(token_addr).setSymbol("Test1");
-        assertEq(ERC20Ubiquity(token_addr).symbol(), "Test1");
+        new ERC20Ubiquity(uad_manager_addr, "Test", "Test");
     }
 
-    function test_setName() public {
-        vm.expectRevert("ERC20: deployer must be manager admin");
-        ERC20Ubiquity(token_addr).setName("Test1");
-
-        vm.prank(admin);
-        ERC20Ubiquity(token_addr).setName("Test1");
-        assertEq(ERC20Ubiquity(token_addr).name(), "Test1");
+    function testConstructor_ShoulSetConstructorParams() public {
+        assertEq(ERC20Ubiquity(token_addr).name(), "Test");
+        assertEq(ERC20Ubiquity(token_addr).symbol(), "Test");
+        assertEq(address(ERC20Ubiquity(token_addr).manager()), uad_manager_addr);
+        assertEq(ERC20Ubiquity(token_addr).DOMAIN_SEPARATOR(), 0xa4e44b8251719cd84da0b54adf012df7fac7d337d5d77db9ce210938952bdf7d);
     }
 
-    function test_mintAndBurn() public {
-        // test onlyMinter and mint
-        address mock_addr1 = address(0x123);
-        address mock_addr2 = address(0x234);
-        vm.expectRevert("Governance token: not minter");
-        ERC20Ubiquity(token_addr).mint(mock_addr1, 100);
+    function testSetSymbol_ShouldRevert_IfMethodIsCalledNotByAdmin() public {
+        vm.expectRevert("ERC20: deployer must be manager admin");
+        ERC20Ubiquity(token_addr).setSymbol("ANY_SYMBOL");
+    }
 
-        uint256 before_bal = ERC20Ubiquity(token_addr).balanceOf(mock_addr1);
+    function testSetSymbol_ShouldSetSymbol() public {
         vm.prank(admin);
-        vm.expectEmit(true, true, false, true);
-        emit Minting(mock_addr1, admin, 100);
-        ERC20Ubiquity(token_addr).mint(mock_addr1, 100);
-        uint256 after_bal = ERC20Ubiquity(token_addr).balanceOf(mock_addr1);
-        assertEq(after_bal - before_bal, 100);
+        ERC20Ubiquity(token_addr).setSymbol("ANY_SYMBOL");
+        assertEq(ERC20Ubiquity(token_addr).symbol(), "ANY_SYMBOL");
+    }
 
-        // test onlyPauser and check if transfer reverts
-        vm.expectRevert("Governance token: not pauser");
-        ERC20Ubiquity(token_addr).pause();
+    function testSetName_ShouldRevert_IfMethodIsCalledNotByAdmin() public {
+        vm.expectRevert("ERC20: deployer must be manager admin");
+        ERC20Ubiquity(token_addr).setName("ANY_NAME");
+    }
+
+    function testSetName_ShouldSetName() public {
+        vm.prank(admin);
+        ERC20Ubiquity(token_addr).setName("ANY_NAME");
+        assertEq(ERC20Ubiquity(token_addr).name(), "ANY_NAME");
+    }
+
+    function testPermit_ShouldRevert_IfDeadlineExpired() public {
+        // create owner and spender addresses
+        uint ownerPrivateKey = 0x1;
+        uint spenderPrivateKey = 0x2;
+        address owner = vm.addr(ownerPrivateKey);
+        address spender = vm.addr(spenderPrivateKey);
+        // create owner's signature
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                ERC20Ubiquity(token_addr).DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        ERC20Ubiquity(token_addr).PERMIT_TYPEHASH(),
+                        owner,
+                        spender,
+                        1e18,
+                        ERC20Ubiquity(token_addr).nonces(owner),
+                        0
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        // run permit
+        vm.prank(spender);
+        vm.expectRevert("Dollar: EXPIRED");
+        ERC20Ubiquity(token_addr).permit(
+            owner,
+            spender,
+            1e18,
+            0,
+            v,
+            r,
+            s
+        );
+    }
+
+    function testPermit_ShouldRevert_IfSignatureIsInvalid() public {
+        // create owner and spender addresses
+        uint ownerPrivateKey = 0x1;
+        uint spenderPrivateKey = 0x2;
+        address owner = vm.addr(ownerPrivateKey);
+        address spender = vm.addr(spenderPrivateKey);
+        // create owner's signature
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                ERC20Ubiquity(token_addr).DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        ERC20Ubiquity(token_addr).PERMIT_TYPEHASH(),
+                        owner,
+                        spender,
+                        1e18,
+                        ERC20Ubiquity(token_addr).nonces(owner),
+                        1 days
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(spenderPrivateKey, digest);
+        // run permit
+        vm.prank(spender);
+        vm.expectRevert("Dollar: INVALID_SIGNATURE");
+        ERC20Ubiquity(token_addr).permit(
+            owner,
+            spender,
+            1e18,
+            1 days,
+            v,
+            r,
+            s
+        );
+    }
+
+    function testPermit_ShouldIncreaseSpenderAllowance() public {
+        // create owner and spender addresses
+        uint ownerPrivateKey = 0x1;
+        uint spenderPrivateKey = 0x2;
+        address owner = vm.addr(ownerPrivateKey);
+        address spender = vm.addr(spenderPrivateKey);
+        // create owner's signature
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                ERC20Ubiquity(token_addr).DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        ERC20Ubiquity(token_addr).PERMIT_TYPEHASH(),
+                        owner,
+                        spender,
+                        1e18,
+                        ERC20Ubiquity(token_addr).nonces(owner),
+                        1 days
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        // run permit
+        vm.prank(spender);
+        ERC20Ubiquity(token_addr).permit(
+            owner,
+            spender,
+            1e18,
+            1 days,
+            v,
+            r,
+            s
+        );
+        assertEq(ERC20Ubiquity(token_addr).allowance(owner, spender), 1e18);
+        assertEq(ERC20Ubiquity(token_addr).nonces(owner), 1);
+    }
+
+    function testBurn_ShouldRevert_IfContractIsPaused() public {
         vm.prank(admin);
         ERC20Ubiquity(token_addr).pause();
-        vm.prank(mock_addr1);
         vm.expectRevert("Pausable: paused");
-        ERC20Ubiquity(token_addr).transfer(mock_addr2, 10);
+        ERC20Ubiquity(token_addr).burn(50);
+    }
 
+    function testBurn_ShouldBurnTokens() public {
+        // mint 100 tokens to user
+        address mockAddress = address(0x1);
         vm.prank(admin);
-        ERC20Ubiquity(token_addr).unpause();
+        ERC20Ubiquity(token_addr).mint(mockAddress, 100);
+        assertEq(ERC20Ubiquity(token_addr).balanceOf(mockAddress), 100);
+        // burn 50 tokens from user
+        vm.prank(mockAddress);
+        vm.expectEmit(true, true, true, true);
+        emit Burning(mockAddress, 50);
+        ERC20Ubiquity(token_addr).burn(50);
+        assertEq(ERC20Ubiquity(token_addr).balanceOf(mockAddress), 50);
+    }
 
-        // test burn, onlyBurner and burnFrom
-        before_bal = ERC20Ubiquity(token_addr).balanceOf(mock_addr1);
-        vm.prank(mock_addr1);
-        vm.expectEmit(true, false, false, true);
-        emit Burning(mock_addr1, 10);
-        ERC20Ubiquity(token_addr).burn(10);
-        after_bal = ERC20Ubiquity(token_addr).balanceOf(mock_addr1);
-        assertEq(before_bal - after_bal, 10);
-
-        vm.prank(mock_addr2);
+    function testBurnFrom_ShouldRevert_IfCalledNotByTheBurnerRole() public {
+        address mockAddress = address(0x1);
         vm.expectRevert("Governance token: not burner");
-        ERC20Ubiquity(token_addr).burnFrom(mock_addr1, 10);
+        ERC20Ubiquity(token_addr).burnFrom(mockAddress, 50);
+    }
 
-        before_bal = ERC20Ubiquity(token_addr).balanceOf(mock_addr1);
+    function testBurnFrom_ShouldRevert_IfContractIsPaused() public {
+        // mint 100 tokens to user
+        address mockAddress = address(0x1);
+        vm.prank(admin);
+        ERC20Ubiquity(token_addr).mint(mockAddress, 100);
+        assertEq(ERC20Ubiquity(token_addr).balanceOf(mockAddress), 100);
+        // create burner role
+        address burner = address(0x2);
         vm.prank(admin);
         UbiquityAlgorithmicDollarManager(uad_manager_addr).grantRole(
-            keccak256("UBQ_BURNER_ROLE"), mock_addr2
+            keccak256("UBQ_BURNER_ROLE"), burner
         );
+        // admin pauses contract
+        vm.prank(admin);
+        ERC20Ubiquity(token_addr).pause();
+        // burn 50 tokens for user
+        vm.prank(burner);
+        vm.expectRevert("Pausable: paused");
+        ERC20Ubiquity(token_addr).burnFrom(mockAddress, 50);
+    }
 
-        vm.prank(mock_addr2);
-        vm.expectEmit(true, false, false, true);
-        emit Burning(mock_addr1, 10);
-        ERC20Ubiquity(token_addr).burnFrom(mock_addr1, 10);
-        after_bal = ERC20Ubiquity(token_addr).balanceOf(mock_addr1);
-        assertEq(before_bal - after_bal, 10);
+    function testBurnFrom_ShouldBurnTokensFromAddress() public {
+        // mint 100 tokens to user
+        address mockAddress = address(0x1);
+        vm.prank(admin);
+        ERC20Ubiquity(token_addr).mint(mockAddress, 100);
+        assertEq(ERC20Ubiquity(token_addr).balanceOf(mockAddress), 100);
+        // create burner role
+        address burner = address(0x2);
+        vm.prank(admin);
+        UbiquityAlgorithmicDollarManager(uad_manager_addr).grantRole(
+            keccak256("UBQ_BURNER_ROLE"), burner
+        );
+        // burn 50 tokens for user
+        vm.prank(burner);
+        vm.expectEmit(true, true, true, true);
+        emit Burning(mockAddress, 50);
+        ERC20Ubiquity(token_addr).burnFrom(mockAddress, 50);
+        assertEq(ERC20Ubiquity(token_addr).balanceOf(mockAddress), 50);
+    }
+
+    function testMint_ShouldRevert_IfCalledNotByTheMinterRole() public {
+        address mockAddress = address(0x1);
+        vm.expectRevert("Governance token: not minter");
+        ERC20Ubiquity(token_addr).mint(mockAddress, 100);
+    }
+
+    function testMint_ShouldRevert_IfContractIsPaused() public {
+        vm.startPrank(admin);
+        ERC20Ubiquity(token_addr).pause();
+        address mockAddress = address(0x1);
+        vm.expectRevert("Pausable: paused");
+        ERC20Ubiquity(token_addr).mint(mockAddress, 100);
+        vm.stopPrank();
+    }
+
+    function testMint_ShouldMintTokens() public {
+        address mockAddress = address(0x1);
+        uint balanceBefore = ERC20Ubiquity(token_addr).balanceOf(mockAddress);
+        vm.prank(admin);
+        vm.expectEmit(true, true, false, true);
+        emit Minting(mockAddress, admin, 100);
+        ERC20Ubiquity(token_addr).mint(mockAddress, 100);
+        uint256 balanceAfter = ERC20Ubiquity(token_addr).balanceOf(mockAddress);
+        assertEq(balanceAfter - balanceBefore, 100);
+    }
+
+    function testPause_ShouldRevert_IfCalledNotByThePauserRole() public {
+        vm.expectRevert("Governance token: not pauser");
+        ERC20Ubiquity(token_addr).pause();
+    }
+
+    function testPause_ShouldPauseContract() public {
+        assertFalse(ERC20Ubiquity(token_addr).paused());
+        vm.prank(admin);
+        ERC20Ubiquity(token_addr).pause();
+        assertTrue(ERC20Ubiquity(token_addr).paused());
+    }
+
+    function testUnpause_ShouldRevert_IfCalledNotByThePauserRole() public {
+        vm.expectRevert("Governance token: not pauser");
+        ERC20Ubiquity(token_addr).unpause();
+    }
+
+    function testUnpause_ShouldUnpauseContract() public {
+        vm.startPrank(admin);
+        ERC20Ubiquity(token_addr).pause();
+        assertTrue(ERC20Ubiquity(token_addr).paused());
+        ERC20Ubiquity(token_addr).unpause();
+        assertFalse(ERC20Ubiquity(token_addr).paused());
+        vm.stopPrank();
+    }
+
+    function testName_ShouldReturnTokenName() public {
+        assertEq(ERC20Ubiquity(token_addr).name(), "Test");
+    }
+
+    function testSymbol_ShouldReturnSymbolName() public {
+        assertEq(ERC20Ubiquity(token_addr).symbol(), "Test");
+    }
+
+    function testTransfer_ShouldRevert_IfContractIsPaused() public {
+        // deploy contract with exposed internal methods
+        vm.prank(admin);
+        ERC20UbiquityHarness erc20Ubiquity = new ERC20UbiquityHarness(uad_manager_addr, "Test", "Test");
+        // admin pauses contract
+        vm.prank(admin);
+        erc20Ubiquity.pause();
+        // transfer tokens to user
+        address userAddress = address(0x1);
+        vm.prank(admin);
+        vm.expectRevert("Pausable: paused");
+        erc20Ubiquity.exposed_transfer(admin, userAddress, 10);
+    }
+
+    function testTransfer_ShouldTransferTokens() public {
+        // deploy contract with exposed internal methods
+        vm.prank(admin);
+        ERC20UbiquityHarness erc20Ubiquity = new ERC20UbiquityHarness(uad_manager_addr, "Test", "Test");
+        // mint tokens to admin
+        vm.prank(admin);
+        erc20Ubiquity.mint(admin, 100);
+        // transfer tokens to user
+        address userAddress = address(0x1);
+        assertEq(erc20Ubiquity.balanceOf(userAddress), 0);
+        vm.prank(admin);
+        erc20Ubiquity.exposed_transfer(admin, userAddress, 10);
+        assertEq(erc20Ubiquity.balanceOf(userAddress), 10);
     }
 }


### PR DESCRIPTION
This PR adds more tests for https://github.com/ubiquity/ubiquity-dollar/blob/development/packages/contracts/src/dollar/ERC20Ubiquity.sol

Test coverage before:
```
|-------------------------------------------------+-----------------+-----------------+----------------+-----------------|
| src/dollar/ERC20Ubiquity.sol                    | 68.42% (13/19)  | 61.90% (13/21) |  0.00% (0/4)  | 91.67% (11/12) |
|-------------------------------------------------+-----------------+-----------------+----------------+-----------------|
```

Test coverage after:
```
|-------------------------------------------------+-----------------+-----------------+----------------+-----------------|
| src/dollar/ERC20Ubiquity.sol                    | 100.00% (19/19) | 100.00% (21/21) | 100.00% (4/4)  | 100.00% (12/12) |
|-------------------------------------------------+-----------------+-----------------+----------------+-----------------|
```