### PR TITLE
update github-script to v6.3.3 resolves #312

### DIFF
--- a/.github/workflows/received-workflow-and-deploy.yml
+++ b/.github/workflows/received-workflow-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "18"
 
       - name: "Download artifact"
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6.3.3
         with:
           script: |
             const fs = require("fs");


### PR DESCRIPTION
Hi,
I was looking into this issue and it seems like the old version of github-script (3.1.0) was causing the warning message:
"Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"
The version is a major upgrade so I'm not sure if there are other consequences so please rollback the changes if the workflow fails.

Thanks,
Keita

Resolves #312

<!-- You must link the issue number -->
https://github.com/ubiquity/ubiquity-dollar/issues/312