### PR TITLE
Octokit context is available at github.rest* instead of github from v5 github-script

### DIFF
--- a/utils/download_artifact.js
+++ b/utils/download_artifact.js
@@ -1,6 +1,6 @@
 module.exports = async ({ github, context, fs, workflow_run_id, workspace }) => {
   console.log("download_artifact.....");
-  const artifacts = await github.actions.listWorkflowRunArtifacts({
+  const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
     owner: context.repo.owner,
     repo: context.repo.repo,
     run_id: workflow_run_id,
@@ -8,7 +8,7 @@ module.exports = async ({ github, context, fs, workflow_run_id, workspace }) => 
   const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
     return artifact.name == "pr";
   })[0];
-  const download = await github.actions.downloadArtifact({
+  const download = await github.rest.actions.downloadArtifact({
     owner: context.repo.owner,
     repo: context.repo.repo,
     artifact_id: matchArtifact.id,


### PR DESCRIPTION
@0xcodercrane Looking at the log, it seems like the API calls in the github script were failing (Cannot read properties of undefined (reading 'listWorkflowRunArtifacts')). There was a change in v5 that's causing that so I updated the calls to include the keyword "rest" before the call. 
Please take look at the change below:
https://github.com/actions/github-script#breaking-changes-in-v5

I'm not changing the logic of this script so this should be more of a syntax fix.
Please let me know if you have any questions.

Resolves #312 #336 #337

<!-- You must link the issue number -->
https://github.com/ubiquity/ubiquity-dollar/pull/336
https://github.com/ubiquity/ubiquity-dollar/pull/337