### PR TITLE
fix #170

### DIFF
--- a/packages/contracts/src/dollar/StakingShare.sol
+++ b/packages/contracts/src/dollar/StakingShare.sol
@@ -39,6 +39,14 @@ contract StakingShare is ERC1155, ERC1155Burnable, ERC1155Pausable {
         );
         _;
     }
+    
+    modifier onlyStakingManager() {
+        require(
+            manager.hasRole(manager.STAKING_MANAGER_ROLE(), msg.sender),
+            "Governance token: not staking manager"
+        );
+        _;
+    }
 
     modifier onlyBurner() {
         require(
@@ -226,5 +234,13 @@ contract StakingShare is ERC1155, ERC1155Burnable, ERC1155Pausable {
         bytes memory data
     ) internal virtual override (ERC1155, ERC1155Pausable) {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+    }
+    
+    /**
+    *@dev this function is used to allow the staking manage to fix the uri should anything be wrong with the current one.
+     */
+    
+    function setUri(string memory newUri) external onlyStakingManager{
+        _uri = newUri;
     }
 }

--- a/packages/contracts/test/dollar/StakingShare.t.sol
+++ b/packages/contracts/test/dollar/StakingShare.t.sol
@@ -126,4 +126,21 @@ contract DepositStateTest is DepositState {
         uint256[] memory ids_ = stakingShare.holderTokens(stakingMinAccount);
         assertEq(ids, ids_);
     }
+
+    function testSetUri() public {
+        string memory stringTest = "{'name':'Bonding Share','description':," 
+        "'Ubiquity Bonding Share V2',"
+        "'image': 'https://bafybeifibz4fhk4yag5reupmgh5cdbm2oladke4zfd7ldyw7avgipocpmy.ipfs.infura-ipfs.io/'}";
+        vm.prank(admin);
+        stakingShare.setUri(stringTest);
+        assertEq(stakingShare.uri(1), stringTest, 'the uri is not set correctly by the method');
+    }
+
+    function testCannotSetUriFromNonAllowedAddress() public{
+        string memory stringTest ="{'a parsed json':'value'}";
+        vm.expectRevert();
+        vm.prank(fifthAccount);
+        stakingShare.setUri(stringTest);
+    }
 }
+   


### PR DESCRIPTION
Resolves #170 

Add a setUri function 
Add a only onlyStakingManager for access control to SetUri function
Add tests for setUri
Make _uri variable in ERC1155.sol from the the open Zeppelin library


