### PR TITLE
Added Deploy Anvil action

### DIFF
--- a/.github/workflows/deploy-anvil.yml
+++ b/.github/workflows/deploy-anvil.yml
@@ -1,0 +1,26 @@
+on: workflow_dispatch
+
+name: Deploy Anvil
+
+jobs:
+  deploy-anvil:
+    name: Deploy Anvil
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Install cloudflared
+        uses: supplypike/setup-bin@v3
+        with:
+          uri: 'https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64'
+          name: 'cloudflared'
+          version: 'latest'
+      - name: Tunnel
+        id: tunnel
+        run: cloudflared tunnel --url http://localhost:8545 &
+        shell: bash
+      - name: Run anvil
+        run: anvil
+        shell: bash


### PR DESCRIPTION
Resolves #425

Adds an action to deploy Anvil with Cloudflare Tunnel.

It can be triggered with an API request or via the Github UI:

<img width="1651" alt="Screenshot 2022-12-30 at 17 18 36" src="https://user-images.githubusercontent.com/5501872/210096560-0c6906e4-d2f2-44e1-9e50-9dd1efc01177.png">


Example run: https://github.com/acaldas/ubiquity-dollar/actions/runs/3830464216/jobs/6518361373

<img width="684" alt="Screenshot 2022-12-30 at 17 22 49" src="https://user-images.githubusercontent.com/5501872/210096897-a0fcfa39-8a58-4bc2-bd55-878a296fac84.png">

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
