### PR TITLE
fix: cloudflare pages build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
     "@lavamoat/allow-scripts": "^2.3.0",
-    "@lavamoat/preinstall-always-fail": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
     "cspell": "^6.17.0",
@@ -49,7 +48,6 @@
   "lavamoat": {
     "allowScripts": {
       "$root$": true,
-      "@lavamoat/preinstall-always-fail": false,
       "bufferutil": true,
       "utf-8-validate": true,
       "styled-components": false,
@@ -59,7 +57,8 @@
       "secp256k1": true,
       "classic-level": true,
       "@ubiquity/monorepo": true,
-      "napi-macros/example": true
+      "napi-macros/example": true,
+      "husky": true
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,13 +1724,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lavamoat/preinstall-always-fail@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@lavamoat/preinstall-always-fail@npm:1.0.0"
-  checksum: 93af02b34c8a7d99296025fd2052272f26310b38998c07b39f698ba395a5543b450dea41d3a26005c83a634738e6f7de01a7cea0eb5552cfe83abe619c3e7b31
-  languageName: node
-  linkType: hard
-
 "@metamask/detect-provider@npm:^1.2.0":
   version: 1.2.0
   resolution: "@metamask/detect-provider@npm:1.2.0"
@@ -3180,7 +3173,6 @@ __metadata:
     "@commitlint/cli": ^17.3.0
     "@commitlint/config-conventional": ^17.3.0
     "@lavamoat/allow-scripts": ^2.3.0
-    "@lavamoat/preinstall-always-fail": ^1.0.0
     "@typescript-eslint/eslint-plugin": ^5.32.0
     "@typescript-eslint/parser": ^5.32.0
     cspell: ^6.17.0


### PR DESCRIPTION
- `@lavamoat/preinstall-always-fail` was causing the build to fail

- the environment should be configured like this:

<html>
<body>
<!--StartFragment-->

PYTHON_VERSION | 3.7
-- | --


<!--EndFragment-->
</body>
</html>

![image](https://user-images.githubusercontent.com/109317559/210631364-792a81e5-01ca-4797-bb9a-f6b78684594c.png)

- Deployed at: https://81be5415.ubiquity-dollar-7i7.pages.dev/
- [Cloudflare Log File](https://github.com/ubiquity/ubiquity-dollar/files/10346858/ubiquity-dollar.81be5415-003a-4042-b1fd-f070af9bb51f.log)


Resolves #448 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
