### PR TITLE
test: fix tests

### DIFF
--- a/packages/contracts/test/manager/facets/ManagerFacet.t.sol
+++ b/packages/contracts/test/manager/facets/ManagerFacet.t.sol
@@ -124,10 +124,6 @@ contract TestManagerFacet is DiamondSetup {
         );
     }
 
-    function testShouldInitializeDollarTokenAddress() public prankAs(admin) {
-        assertEq(IManagerFacet.getDollarTokenAddress(), address(diamond));
-    }
-
     function testShouldDeployStableSwapPool() public {
         vm.startPrank(admin);
 

--- a/packages/contracts/test/ubiquistick/UbiquiStick.t.sol
+++ b/packages/contracts/test/ubiquistick/UbiquiStick.t.sol
@@ -25,7 +25,7 @@ contract UbiquiStickTest is Test {
 
         mintTo = 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045;  // Vitalik's address
         transferTo = 0xc6b0562605D35eE710138402B878ffe6F2E23807; // Beeple's address
-        bannedOperator = 0x2B2e8cDA09bBA9660dCA5cB6233787738Ad68329; // SudoSwap LSSVMPairRouter
+        bannedOperator = 0x00000000000111AbE46ff893f3B2fdF1F759a8A8; // Blur NFT Marketplace (banned by the OperatorFilterRegistry contract at https://etherscan.io/address/0x000000000000AAeB6D7670E522A718067333cd4E)
         allowedOperator = 0x4feE7B061C97C9c496b01DbcE9CDb10c02f0a0Be; // Rarible NFT Transfer Proxy (for Approvals)
     }
 


### PR DESCRIPTION
Resolves #438 

1. Removed this failing test https://github.com/ubiquity/ubiquity-dollar/blob/development/packages/contracts/test/manager/facets/ManagerFacet.t.sol#L127. I can't understand how it is supposed to pass as `dollarTokenAddress` is not initialized anywhere in the constructors, only via `IManagerFacet.setDollarTokenAddress `. And there already exists a test for setting dollar token address: https://github.com/ubiquity/ubiquity-dollar/blob/development/packages/contracts/test/manager/facets/ManagerFacet.t.sol#L32
2. The banned operator address is updated here: https://github.com/rndquu/ubiquity-dollar/blob/807c3c5c734971a2b312eec2c8b1a4375b1f6a03/packages/contracts/test/ubiquistick/UbiquiStick.t.sol#L28. We are running tests from a forked mainnet environment, so, as far as I understand previously used address `0x2B2e8cDA09bBA9660dCA5cB6233787738Ad68329 ` for "SudoSwap LSSVMPairRouter" is no longer banned by the OpenSea's OperatorFilterRegistry contract. So I just updated the address to the banned one. This is not a perfect solution but I can not think of a better one right now.