### PR TITLE
docs: update bounty program URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Introducing the flagship product of [Ubiquity DAO](https://ubq.fi/). The Ubiquit
 
 - We offer incentives for contributors to solve issues.
 
-- Please learn how to contribute via our bounty program [here](https://github.com/ubiquity/ubiquity-dollar/wiki/Bounty-Rules/).
+- Please learn how to contribute via our bounty program [here](https://dao.ubq.fi/devpool).
 
 ## Yarn Workspaces
 


### PR DESCRIPTION
The old bounty program wiki page is somehow deleted from https://github.com/ubiquity/ubiquity-dollar/wiki/Bounty-Rules, so we should use a new one https://dao.ubq.fi/devpool