### PR TITLE
refactor: resolve RPC rate limiting

### DIFF
--- a/packages/contracts/scripts/runner/conf.ts
+++ b/packages/contracts/scripts/runner/conf.ts
@@ -7,6 +7,8 @@ export const RPC_LIST: string[] = [
   "https://api.securerpc.com/v1",
 ];
 
+export const LOCAL_RPC = "http://127.0.0.1:8545";
+
 export const RPC_BODY = JSON.stringify({
   jsonrpc: "2.0",
   method: "eth_getBlockByNumber",

--- a/packages/contracts/scripts/runner/rpcutil.ts
+++ b/packages/contracts/scripts/runner/rpcutil.ts
@@ -1,0 +1,80 @@
+import axios from "axios";
+import { spawn } from "child_process";
+import { performance } from "node:perf_hooks";
+import { RETRY_COUNT, RETRY_DELAY, RPC_BODY, RPC_HEADER, RPC_LIST } from "./conf";
+
+type DataType = {
+  jsonrpc: string;
+  id: number;
+  result: {
+    number: string;
+    timestamp: string;
+    hash: string;
+  };
+};
+
+const verifyBlock = (data: DataType) => {
+  try {
+    const { jsonrpc, id, result } = data;
+    const { number, timestamp, hash } = result;
+    return jsonrpc === "2.0" && id === 1 && parseInt(number, 16) > 0 && parseInt(timestamp, 16) > 0 && hash.match(/[0-9|a-f|A-F|x]/gm)?.join("").length === 66;
+  } catch (error) {
+    return false;
+  }
+};
+
+const getRPC = async () => {
+  const promises = RPC_LIST.map(async (baseURL: string) => {
+    try {
+      const startTime = performance.now();
+      const API = axios.create({
+        baseURL,
+        headers: RPC_HEADER,
+      });
+
+      const { data } = await API.post("", RPC_BODY);
+      const endTime = performance.now();
+      const latency = endTime - startTime;
+      if (await verifyBlock(data)) {
+        return Promise.resolve({
+          latency,
+          baseURL,
+        });
+      } else {
+        return Promise.reject();
+      }
+    } catch (error) {
+      return Promise.reject();
+    }
+  });
+  const { baseURL: optimalRPC } = await Promise.any(promises);
+  return optimalRPC;
+};
+
+let shouldSkip = false;
+let retryCount = 0;
+const procFork = async () => {
+  const optimalRPC = await getRPC();
+  console.log(`using ${optimalRPC} for unit-testing...`);
+  const command = spawn("forge", ["test", "--fork-url", optimalRPC as string]);
+  shouldSkip = false;
+  command.stdout.on("data", (output: unknown) => {
+    console.log(output?.toString());
+  });
+  command.stderr.on("data", (output: unknown) => {
+    console.log(output?.toString());
+    if (shouldSkip === false && retryCount <= RETRY_COUNT) {
+      retryCount++;
+      setTimeout(() => {
+        procFork();
+      }, RETRY_DELAY);
+      shouldSkip = true;
+    }
+  });
+  command.on("close", (code: number) => {
+    // if linux command exit code is not success (0) then throw an error
+    if (code !== 0) throw new Error("Failing tests");
+  });
+};
+
+procFork();

--- a/packages/contracts/scripts/runner/runner.ts
+++ b/packages/contracts/scripts/runner/runner.ts
@@ -1,60 +1,11 @@
-import axios from "axios";
 import { spawn } from "child_process";
-import { performance } from "node:perf_hooks";
-import { RETRY_COUNT, RETRY_DELAY, RPC_BODY, RPC_HEADER, RPC_LIST } from "./conf";
-
-type DataType = {
-  jsonrpc: string;
-  id: number;
-  result: {
-    number: string;
-    timestamp: string;
-    hash: string;
-  };
-};
-
-const verifyBlock = (data: DataType) => {
-  try {
-    const { jsonrpc, id, result } = data;
-    const { number, timestamp, hash } = result;
-    return jsonrpc === "2.0" && id === 1 && parseInt(number, 16) > 0 && parseInt(timestamp, 16) > 0 && hash.match(/[0-9|a-f|A-F|x]/gm)?.join("").length === 66;
-  } catch (error) {
-    return false;
-  }
-};
-
-const getRPC = async () => {
-  const promises = RPC_LIST.map(async (baseURL: string) => {
-    try {
-      const startTime = performance.now();
-      const API = axios.create({
-        baseURL,
-        headers: RPC_HEADER,
-      });
-
-      const { data } = await API.post("", RPC_BODY);
-      const endTime = performance.now();
-      const latency = endTime - startTime;
-      if (await verifyBlock(data)) {
-        return Promise.resolve({
-          latency,
-          baseURL,
-        });
-      } else {
-        return Promise.reject();
-      }
-    } catch (error) {
-      return Promise.reject();
-    }
-  });
-  const { baseURL: optimalRPC } = await Promise.any(promises);
-  return optimalRPC;
-};
+import { LOCAL_RPC, RETRY_COUNT, RETRY_DELAY } from "./conf";
 
 let shouldSkip = false;
 let retryCount = 0;
 const procFork = async () => {
-  const optimalRPC = await getRPC();
+  const optimalRPC = LOCAL_RPC;
+  const anvil = spawn("anvil");
   console.log(`using ${optimalRPC} for unit-testing...`);
   const command = spawn("forge", ["test", "--fork-url", optimalRPC as string]);
   shouldSkip = false;
@@ -72,6 +23,7 @@ const procFork = async () => {
     }
   });
   command.on("close", (code: number) => {
+    anvil.kill();
     // if linux command exit code is not success (0) then throw an error
     if (code !== 0) throw new Error("Failing tests");
   });


### PR DESCRIPTION
- Run tests on `anvil` from now on
- Move current RPC utility function to `rpcutil.ts`
- Add `localRPC` config (using exact IP instead of _localhost_ to avoid potential resolution errors)

As it turns out, GitHub Actions use shared IPs which oftentimes get rate-limited by
the RPC providers,
If we make a bunch of calls.

I've looked around and found that the same process can spin up an anvil instance to run the tests.

Resolves #473 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
