### PR TITLE
fix: anvil ts mnemonic

### DIFF
--- a/packages/contracts/scripts/anvil/anvil.ts
+++ b/packages/contracts/scripts/anvil/anvil.ts
@@ -7,13 +7,18 @@ import path from "path";
 
 let optimalRPC;
 
+const envPath = path.join(__dirname, "/../../.env");
+if (!fs.existsSync(envPath)) {
+  throw new Error("Env file not found");
+}
+
+const env = loadEnv(envPath);
+
 const getUrl = async () => {
-  const envPath = path.join(__dirname, "/../../.env");
-
-  const env = loadEnv(envPath);
-
   return env.rpcUrl;
 };
+
+const mnemonic = env.mnemonic;
 
 (async () => {
   optimalRPC = await getUrl();
@@ -21,7 +26,7 @@ const getUrl = async () => {
     optimalRPC = (await getRPC()).toString();
   }
   console.log(`using ${optimalRPC} for anvil...`);
-  const command = spawn("anvil", ["-f", optimalRPC as string, "-m", "test test test test test test test test test test test junk", "--chain-id", "31337"]);
+  const command = spawn("anvil", ["-f", optimalRPC as string, "-m", mnemonic as string, "--chain-id", "31337"]);
   command.stdout.on("data", (output: any) => {
     console.log(output.toString());
   });

--- a/packages/contracts/scripts/shared/helpers/loadEnv.ts
+++ b/packages/contracts/scripts/shared/helpers/loadEnv.ts
@@ -11,6 +11,7 @@ export const loadEnv = (path: string): Env => {
   const etherscanApiKey = process.env.ETHERSCAN_API_KEY;
   const curveWhale = process.env.CURVE_WHALE || "0x4486083589A063ddEF47EE2E4467B5236C508fDe";
   const _3CRV = process.env.USD3CRV_TOKEN || "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490";
+  const mnemonic = process.env.MNEMONIC || "test test test test test test test test test test test junk";
 
   return {
     rpcUrl,
@@ -18,6 +19,7 @@ export const loadEnv = (path: string): Env => {
     adminAddress,
     etherscanApiKey,
     curveWhale,
-    _3CRV
+    _3CRV,
+    mnemonic,
   };
 };

--- a/packages/contracts/scripts/shared/types/env.ts
+++ b/packages/contracts/scripts/shared/types/env.ts
@@ -5,4 +5,5 @@ export type Env = {
   etherscanApiKey?: string;
   curveWhale: string;
   _3CRV: string;
+  mnemonic: string;
 };


### PR DESCRIPTION
Resolves #

quick fix cause anvil.ts was hardcoded to use one mnemonic instead of pulling from .env

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
