### PR TITLE
Fix/dev build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,6 +68,3 @@ jobs:
         run: yarn dev:dapp &
         env:
           CI: true
-
-      - name: UI Tests
-        run: npx tsx packages/dapp/test/puppeteer.ts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,7 @@ name: Build & Test
 
 on:
   push:
+  pull_request:
     tag:
       - "v*"
 

--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -5,3 +5,4 @@ solidity-linked-list/=lib/solidity-linked-list
 @uniswap/v2-core/contracts/=lib/Uniswap/v2-core/contracts
 @uniswap/v2-periphery/contracts/=lib/Uniswap/v2-periphery/contracts
 abdk/=lib/abdk-libraries-solidity/
+operator-filter-registry/=lib/operator-filter-registry/src

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -13,7 +13,7 @@
     "start": "next dev",
     "clean": "rimraf next types node_modules",
     "build:next": "next build",
-    "build:types": "typechain --show-stack-traces --target ethers-v5 ../contracts/out/**/*.json --out-dir=types"
+    "build:types": "typechain --show-stack-traces --target ethers-v5 ../contracts/out/**/[!(test.sol)]*/*.json --out-dir=types"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.0.0",

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -9,7 +9,6 @@
     "build": "run-s build:types build:next build:export",
     "build:watch": "run-s build:types build:next",
     "build:export": "next export --outdir dist",
-    "test": "tsx test/puppeteer.ts",
     "start": "next dev",
     "clean": "rimraf next types node_modules",
     "build:next": "next build",


### PR DESCRIPTION
fixes `development` branch build

1. The "operator-filter-registry issue" was caused by recent foundry update
2. This line https://github.com/rndquu/ubiquity-dollar/blob/ed010f5a6d0137a36f9fc3447b60bb166269e5e1/packages/dapp/package.json#L15 fixes this error https://github.com/rndquu/ubiquity-dollar/actions/runs/4101383336/jobs/7073110768
3. Removed UI test script because there is no such file `dapp/test/puppeteer.ts `