### PR TITLE
Fix/ci on pr

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,8 +3,6 @@ name: Build & Test
 on:
   push:
   pull_request:
-    tag:
-      - "v*"
 
 jobs:
   build-and-test:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: CodeQL Analysis
 
 on:
+  pull_request:
   push:
 
 jobs:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,6 +1,7 @@
 name: Conventional Commits
 
 on:
+  pull_request:
   push:
     branches: [development]
 

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -1,6 +1,6 @@
 name: Slither Analysis
 
-on: push
+on: workflow_dispatch
 jobs:
   slither-analysis:
     name: Slither Analysis

--- a/.github/workflows/yarn-audit.yml
+++ b/.github/workflows/yarn-audit.yml
@@ -1,6 +1,7 @@
 name: Yarn Audit
 
 on:
+  pull_request:
   push:
 
 jobs:


### PR DESCRIPTION
This PR brings back the "on pull request" handler for the following events:
- CodeQL Analysis
- Conventional Commits
- Yarn Audit

Also the slither CI action is disabled (because it fails) and can be run only manually. If this PR is merged I will add a requirement "enable slither CI action" to this task https://github.com/ubiquity/ubiquity-dollar/issues/536