### PR TITLE
Refactor Cloudflare Pages Build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+on: [push]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    name: Publish to Cloudflare Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: sudo apt -y update && sudo apt -y install libusb-1.0-0-dev libudev-dev
+
+      - name: Setup Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Yarn Install
+        run: yarn install --mode=skip-build && yarn allow-scripts
+
+      - name: Setup Forge
+        run: yarn workspace @ubiquity/contracts forge:install
+
+      - name: Build All
+        run: yarn build
+      # Run a build step here if your project requires
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+          directory: ${{ secrets.CLOUDFLARE_ASSET_DIRECTORY }}


### PR DESCRIPTION
**Project Setup (GitHub secrets):**

**CLOUDFLARE_ACCOUNT_ID =**
> https://dash.cloudflare.com/***/pages
> https://dash.cloudflare.com/abcd1234/pages
> (Here `abcd1234` is your account ID)


**CLOUDFLARE_API_TOKEN =**

> https://dash.cloudflare.com/profile/api-tokens > Create Token > API token templates > Edit Cloudflare Workers > Use Template
> 
> > Account Resources = All Resources
> 
> > Zone Resources = All Zones
> 
> (Detailed Instructions: https://developers.cloudflare.com/workers/wrangler/ci-cd/)


**CLOUDFLARE_ASSET_DIRECTORY =** 

> packages/dapp/dist


**CLOUDFLARE_PROJECT_NAME =**

> npm install -g wrangler
> wrangler login
> wrangler pages project create

_Cloudflare Pages_ couldn't build precompiled foundry package since it relies on
`GLIBC_2.25` and above which _Cloudflare Pages v1_ couldn't provide,
hence we're using _wrangler_ action.

Resolves #529 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
