### PR TITLE
ci: run unit tests only for contracts workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:all": "yarn workspaces foreach run build",
     "build:dapp": "yarn workspace @ubiquity/dapp run build",
     "dev:dapp": "yarn workspace @ubiquity/dapp run start",
-    "test:all": "yarn workspaces foreach run test:unit",
+    "test:all": "yarn workspace @ubiquity/contracts run test:unit",
     "purge:all": "yarn workspaces foreach run purge && rimraf node_modules",
     "prettier:all": "prettier packages/ --write",
     "lint:all": "yarn workspaces foreach run lint",


### PR DESCRIPTION
This PR resolves an issue with running unit tests multiple times like in this [CI run](https://github.com/ubiquity/ubiquity-dollar/actions/runs/4834823676/jobs/8616497305?pr=627)

Yarn considers the following folders to be a workspace:
1. https://github.com/ubiquity/ubiquity-dollar
2. https://github.com/ubiquity/ubiquity-dollar/tree/development/packages/contracts
3. https://github.com/ubiquity/ubiquity-dollar/tree/development/packages/dapp

For each workspace yarn runs `test:unit` and contract unit tests are executed 3 times although the `test:unit` command exists only in the "contracts" workspace.

Right now we have unit tests only for the "contracts" workspace so it is safe to run tests only for the "contracts" workspace.
