### PR TITLE
635 remove unnecessary files from coverage

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -22,13 +22,16 @@ jobs:
         uses: onbjerg/foundry-toolchain@v1
         with:
           version: nightly
+      
+      - name: Install dependencies
+        run: sudo apt-get install lcov
 
       - name: Get development branch coverage
         id: coverage-development
         run: |
           cd packages/contracts
 
-          COVERAGE_DEVELOPMENT_OUTPUT=$(./coverage.sh)
+          COVERAGE_DEVELOPMENT_OUTPUT=$(sh coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
@@ -39,7 +42,7 @@ jobs:
         run: |
           cd packages/contracts
 
-          COVERAGE_PR_OUTPUT=$(./coverage.sh)
+          COVERAGE_PR_OUTPUT=$(sh coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_PR_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Print coverages

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
-          COVERAGE_DEVELOPMENT_OUTPUT=$(npm run coverage)
+          COVERAGE_DEVELOPMENT_OUTPUT=$( cd ./packages/contracts && sh coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
@@ -38,7 +38,7 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
-          COVERAGE_DEVELOPMENT_OUTPUT=$(npm run coverage)
+          COVERAGE_DEVELOPMENT_OUTPUT=$( cd ./packages/contracts && sh coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Print coverages

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
-          COVERAGE_DEVELOPMENT_OUTPUT=$( cd ./packages/contracts && sh coverage.sh)
+          cd ./packages/contracts
+          chmod +x ./coverage.sh
+          COVERAGE_DEVELOPMENT_OUTPUT=$(./coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
@@ -38,7 +40,9 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
-          COVERAGE_DEVELOPMENT_OUTPUT=$( cd ./packages/contracts && sh coverage.sh)
+          cd ./packages/contracts
+          chmod +x ./coverage.sh
+          COVERAGE_DEVELOPMENT_OUTPUT=$(./coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Print coverages

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,35 +29,8 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
-          cd packages/contracts
-          
-          # generates lcov.info
-          forge coverage --report lcov
-
-          # Foundry uses relative paths but Hardhat uses absolute paths.
-          # Convert absolute paths to relative paths for consistency.
-          sed -i -e 's/\/.*solidity.//g' lcov.info
-
-          # Merge lcov files
-          lcov \
-              --rc lcov_branch_coverage=1 \
-              --add-tracefile lcov.info \
-              --output-file merged-lcov.info
-
-          # Filter out node_modules, test, and mock files
-          lcov \
-              --rc lcov_branch_coverage=1 \
-              --remove merged-lcov.info \
-              --output-file filtered-lcov.info \
-              "*node_modules*" "*test*" "*mock*" "*scriptscripting*"
-
-
-          # Generate summary
-          COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
-              --rc lcov_branch_coverage=1 \
-              --list filtered-lcov.info)
-
-          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
+          COVERAGE_DEVELOPMENT_OUTPUT=$(npm run coverage)
+          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
         uses: actions/checkout@v3
@@ -65,35 +38,8 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
-          cd packages/contracts
-          
-          # generates lcov.info
-          forge coverage --report lcov
-
-          # Foundry uses relative paths but Hardhat uses absolute paths.
-          # Convert absolute paths to relative paths for consistency.
-          sed -i -e 's/\/.*solidity.//g' lcov.info
-
-          # Merge lcov files
-          lcov \
-              --rc lcov_branch_coverage=1 \
-              --add-tracefile lcov.info \
-              --output-file merged-lcov.info
-
-          # Filter out node_modules, test, and mock files
-          lcov \
-              --rc lcov_branch_coverage=1 \
-              --remove merged-lcov.info \
-              --output-file filtered-lcov.info \
-              "*node_modules*" "*test*" "*mock*" "*scriptscripting*"
-
-
-          # Generate summary
-          COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
-              --rc lcov_branch_coverage=1 \
-              --list filtered-lcov.info)
-
-          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
+          COVERAGE_DEVELOPMENT_OUTPUT=$(npm run coverage)
+          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Print coverages
         run: |

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,8 +29,35 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
-          COVERAGE_DEVELOPMENT_OUTPUT=$(yarn coverage)
-          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | grep "Total:" | awk -F '|' '{print $2}' | awk '{print $1}' |  tr -d '%') >> $GITHUB_OUTPUT
+          cd packages/contracts
+          
+          # generates lcov.info
+          forge coverage --report lcov
+
+          # Foundry uses relative paths but Hardhat uses absolute paths.
+          # Convert absolute paths to relative paths for consistency.
+          sed -i -e 's/\/.*solidity.//g' lcov.info
+
+          # Merge lcov files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --add-tracefile lcov.info \
+              --output-file merged-lcov.info
+
+          # Filter out node_modules, test, and mock files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --remove merged-lcov.info \
+              --output-file filtered-lcov.info \
+              "*node_modules*" "*test*" "*mock*" "*scriptscripting*"
+
+
+          # Generate summary
+          COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
+              --rc lcov_branch_coverage=1 \
+              --list filtered-lcov.info)
+
+          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
         uses: actions/checkout@v3
@@ -38,8 +65,35 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
-          COVERAGE_PR_OUTPUT=$(yarn coverage)
-          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | grep "Total:" | awk -F '|' '{print $2}' | awk '{print $1}' |  tr -d '%') >> $GITHUB_OUTPUT
+          cd packages/contracts
+          
+          # generates lcov.info
+          forge coverage --report lcov
+
+          # Foundry uses relative paths but Hardhat uses absolute paths.
+          # Convert absolute paths to relative paths for consistency.
+          sed -i -e 's/\/.*solidity.//g' lcov.info
+
+          # Merge lcov files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --add-tracefile lcov.info \
+              --output-file merged-lcov.info
+
+          # Filter out node_modules, test, and mock files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --remove merged-lcov.info \
+              --output-file filtered-lcov.info \
+              "*node_modules*" "*test*" "*mock*" "*scriptscripting*"
+
+
+          # Generate summary
+          COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
+              --rc lcov_branch_coverage=1 \
+              --list filtered-lcov.info)
+
+          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Print coverages
         run: |

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Get PR branch coverage
         id: coverage-pr
-        shell: bash
         run: |
           cd packages/contracts
           

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Get development branch coverage
         id: coverage-development
-        shell: bash
         run: |
           cd packages/contracts
           

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,8 +29,32 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
-          chmod +x ./packages/contracts/coverage.sh
-          COVERAGE_DEVELOPMENT_OUTPUT=$(./packages/contracts/coverage.sh)
+          # generates lcov.info
+          forge coverage --report lcov
+
+          # Foundry uses relative paths but Hardhat uses absolute paths.
+          # Convert absolute paths to relative paths for consistency.
+          sed -i -e 's/\/.*solidity.//g' lcov.info
+
+          # Merge lcov files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --add-tracefile lcov.info \
+              --output-file merged-lcov.info
+
+          # Filter out node_modules, test, and mock files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --remove merged-lcov.info \
+              --output-file filtered-lcov.info \
+              "*node_modules*" "*test*" "*mock*" "*scripts*"
+
+
+          # Generate summary
+          COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
+              --rc lcov_branch_coverage=1 \
+              --list filtered-lcov.info)
+
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
@@ -39,8 +63,31 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
-          chmod +x ./packages/contracts/coverage.sh
-          COVERAGE_DEVELOPMENT_OUTPUT=$(./packages/contracts/coverage.sh)
+          # generates lcov.info
+          forge coverage --report lcov
+
+          # Foundry uses relative paths but Hardhat uses absolute paths.
+          # Convert absolute paths to relative paths for consistency.
+          sed -i -e 's/\/.*solidity.//g' lcov.info
+
+          # Merge lcov files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --add-tracefile lcov.info \
+              --output-file merged-lcov.info
+
+          # Filter out node_modules, test, and mock files
+          lcov \
+              --rc lcov_branch_coverage=1 \
+              --remove merged-lcov.info \
+              --output-file filtered-lcov.info \
+              "*node_modules*" "*test*" "*mock*" "*scripts*"
+
+
+          # Generate summary
+          COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
+              --rc lcov_branch_coverage=1 \
+              --list filtered-lcov.info)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Print coverages

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
+          cd ./packages/contracts
+
           # generates lcov.info
           forge coverage --report lcov
 
@@ -63,6 +65,8 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
+          cd ./packages/contracts
+
           # generates lcov.info
           forge coverage --report lcov
 

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
-          COVERAGE_DEVELOPMENT_OUTPUT=$( cd ./packages/contracts && sh coverage.sh)
+          chmod +x ./packages/contracts/coverage.sh
+          COVERAGE_DEVELOPMENT_OUTPUT=$(./packages/contracts/coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
@@ -38,7 +39,8 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
-          COVERAGE_DEVELOPMENT_OUTPUT=$( cd ./packages/contracts && sh coverage.sh)
+          chmod +x ./packages/contracts/coverage.sh
+          COVERAGE_DEVELOPMENT_OUTPUT=$(./packages/contracts/coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
       - name: Print coverages

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cd packages/contracts
 
-          COVERAGE_DEVELOPMENT_OUTPUT=$(forge coverage)
+          COVERAGE_DEVELOPMENT_OUTPUT=$(./coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
@@ -39,7 +39,7 @@ jobs:
         run: |
           cd packages/contracts
 
-          COVERAGE_PR_OUTPUT=$(forge coverage)
+          COVERAGE_PR_OUTPUT=$(./coverage.sh)
           echo COVERAGE=$(echo "${COVERAGE_PR_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Print coverages

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -29,10 +29,8 @@ jobs:
       - name: Get development branch coverage
         id: coverage-development
         run: |
-          cd packages/contracts
-
-          COVERAGE_DEVELOPMENT_OUTPUT=$(sh coverage.sh)
-          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
+          COVERAGE_DEVELOPMENT_OUTPUT=$(yarn coverage)
+          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | grep "Total:" | awk -F '|' '{print $2}' | awk '{print $1}' |  tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Checkout code in PR branch
         uses: actions/checkout@v3
@@ -40,10 +38,8 @@ jobs:
       - name: Get PR branch coverage
         id: coverage-pr
         run: |
-          cd packages/contracts
-
-          COVERAGE_PR_OUTPUT=$(sh coverage.sh)
-          echo COVERAGE=$(echo "${COVERAGE_PR_OUTPUT}" | tail -n 1 | awk '{print $4}' | tr -d '%') >> $GITHUB_OUTPUT
+          COVERAGE_PR_OUTPUT=$(yarn coverage)
+          echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | grep "Total:" | awk -F '|' '{print $2}' | awk '{print $1}' |  tr -d '%') >> $GITHUB_OUTPUT
 
       - name: Print coverages
         run: |

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Get development branch coverage
         id: coverage-development
+        shell: bash
         run: |
           cd packages/contracts
           
@@ -64,6 +65,7 @@ jobs:
 
       - name: Get PR branch coverage
         id: coverage-pr
+        shell: bash
         run: |
           cd packages/contracts
           

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ out
 packages/contracts/broadcast/*
 packages/dapp/types/
 .vscode/
+/packages/contracts/filtered-lcov.info
+/packages/contracts/lcov.info
+/packages/contracts/merged-lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,4 @@ out
 packages/contracts/broadcast/*
 packages/dapp/types/
 .vscode/
-/packages/contracts/filtered-lcov.info
-/packages/contracts/lcov.info
-/packages/contracts/merged-lcov.info
+/packages/contracts/*.info

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build:dapp": "yarn workspace @ubiquity/dapp run build",
     "dev:dapp": "yarn workspace @ubiquity/dapp run start",
     "test:all": "yarn workspace @ubiquity/contracts run test:unit",
-    "coverage": "cd packages/contracts/ && ./coverage.sh",
+    "coverage": "yarn workspace @ubiquity/contracts run test:coverage",
     "purge:all": "yarn workspaces foreach run purge && rimraf node_modules",
     "prettier:all": "prettier packages/ --write",
     "lint:all": "yarn workspaces foreach run lint",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build:dapp": "yarn workspace @ubiquity/dapp run build",
     "dev:dapp": "yarn workspace @ubiquity/dapp run start",
     "test:all": "yarn workspace @ubiquity/contracts run test:unit",
+    "coverage": "cd packages/contracts/ && ./coverage.sh",
     "purge:all": "yarn workspaces foreach run purge && rimraf node_modules",
     "prettier:all": "prettier packages/ --write",
     "lint:all": "yarn workspaces foreach run lint",

--- a/packages/contracts/coverage.sh
+++ b/packages/contracts/coverage.sh
@@ -1,0 +1,37 @@
+set -e # exit on error
+
+# generates lcov.info
+forge coverage --report lcov
+
+# Foundry uses relative paths but Hardhat uses absolute paths.
+# Convert absolute paths to relative paths for consistency.
+sed -i -e 's/\/.*solidity.//g' lcov.info
+
+# Merge lcov files
+lcov \
+    --rc lcov_branch_coverage=1 \
+    --add-tracefile lcov.info \
+    --output-file merged-lcov.info
+
+# Filter out node_modules, test, and mock files
+lcov \
+    --rc lcov_branch_coverage=1 \
+    --remove merged-lcov.info \
+    --output-file filtered-lcov.info \
+    "*node_modules*" "*test*" "*mock*" "*scriptscripting*"
+
+
+# Generate summary
+lcov \
+    --rc lcov_branch_coverage=1 \
+    --list filtered-lcov.info
+
+# Open more granular breakdown in browser
+if [ "$CI" != "true" ]
+then
+    genhtml \
+        --rc genhtml_branch_coverage=1 \
+        --output-directory coverage \
+        filtered-lcov.info
+    open coverage/index.html
+fi

--- a/packages/contracts/coverage.sh
+++ b/packages/contracts/coverage.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e # exit on error
 
 # generates lcov.info

--- a/packages/contracts/coverage.sh
+++ b/packages/contracts/coverage.sh
@@ -20,7 +20,7 @@ lcov \
     --rc lcov_branch_coverage=1 \
     --remove merged-lcov.info \
     --output-file filtered-lcov.info \
-    "*node_modules*" "*test*" "*mock*" "*scriptscripting*"
+    "*node_modules*" "*test*" "*mock*" "*scripts*"
 
 
 # Generate summary

--- a/packages/contracts/coverage.sh
+++ b/packages/contracts/coverage.sh
@@ -29,7 +29,7 @@ lcov \
     --list filtered-lcov.info
 
 # Open more granular breakdown in browser
-if [ "$CI" != "true" ]
+if [ $HTML_REPORT ]
 then
     genhtml \
         --rc genhtml_branch_coverage=1 \

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,6 +25,7 @@
     "test:unit": "forge test",
     "test:slither": "slither . --compile-force-framework foundry",
     "test:echidna": "echidna-test . --config echidna.config.yml",
+    "test:coverage": "sh ./coverage.sh",
     "start:anvil": "tsx ./scripts/anvil/anvil.ts",
     "prebuild": "run-p clean",
     "deploy": "tsx ./scripts/deploy/deploy.ts",


### PR DESCRIPTION
Resolves #635

In forge currently is impossible to ignore files, but there is a wayaround to tackle this issue.
Please view https://github.com/foundry-rs/foundry/issues/2988 based on this comment https://github.com/foundry-rs/foundry/issues/2988#issuecomment-1505771312 i have setup a `coverage.sh` script to ignore tests, mocks and scriptint solidity files.