### PR TITLE
test: refactor tests with expectEmit

### DIFF
--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -72,14 +72,13 @@ contract ZeroStateBonding is BondingCurveFacetTest {
         baseY = bound(baseY, 1, 1000000);
         uint256 tokenIds;
 
-        vm.expectEmit(true, false, false, true);
-        emit Deposit(secondAccount, collateralDeposited);
-
         vm.prank(admin);
         IBondingCurveFacet.setParams(connectorWeight, baseY);
 
         uint256 initBal = IDollar.balanceOf(secondAccount);
 
+        vm.expectEmit(true, false, false, true);
+        emit Deposit(secondAccount, collateralDeposited);
         IBondingCurveFacet.deposit(collateralDeposited, secondAccount);
 
         uint256 finBal = IDollar.balanceOf(secondAccount);

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -220,6 +220,8 @@ contract ZeroStateStakingTest is ZeroStateStaking {
         require(lpAmount >= 1 && lpAmount <= 100e18);
         require(lockup >= 1 && lockup <= 208);
         uint256 preBalance = metapool.balanceOf(stakingMinAccount);
+        vm.startPrank(stakingMinAccount);
+        metapool.approve(address(IStakingFacet), 2 ** 256 - 1);
         vm.expectEmit(true, false, false, true);
         emit Deposit(
             stakingMinAccount,
@@ -233,8 +235,6 @@ contract ZeroStateStakingTest is ZeroStateStaking {
             lockup,
             (block.number + lockup * IStakingFacet.blockCountInAWeek())
         );
-        vm.startPrank(stakingMinAccount);
-        metapool.approve(address(IStakingFacet), 2 ** 256 - 1);
         IStakingFacet.deposit(lpAmount, lockup);
         assertEq(metapool.balanceOf(stakingMinAccount), preBalance - lpAmount);
     }


### PR DESCRIPTION
In the latest foundry version the tests are failing with:
```
Encountered 1 failing test in test/diamond/facets/BondingCurveFacet.t.sol:ZeroStateBonding
[FAIL. Reason: Expected an emit, but no logs were emitted afterward. You might have mismatched events or not enough events were emitted. Counterexample: calldata=0x5fffbbe400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, args=[0, 0]] testDeposit(uint32,uint256) (runs: 0, μ: 0, ~: 0)

Encountered 1 failing test in test/diamond/facets/StakingFacet.t.sol:ZeroStateStakingTest
[FAIL. Reason: Expected an emit, but no logs were emitted afterward. You might have mismatched events or not enough events were emitted. Counterexample: calldata=0xc237edba00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, args=[0, 0]] testDeposit_Staking(uint256,uint256) (runs: 0, μ: 0, ~: 0)
```

It happens because `vm.expectEmit()` [now works](https://github.com/foundry-rs/foundry/pull/4920) only for the next call

This PR refactors `vm.expectEmit()` to be called right before a function that emits an expected event