### PR TITLE
fix: fix development deploy

### DIFF
--- a/packages/contracts/scripts/deploy/dollar/DevelopmentDeploy.ts
+++ b/packages/contracts/scripts/deploy/dollar/DevelopmentDeploy.ts
@@ -36,6 +36,7 @@ const sendTokens = async () => {
       "10000000000000000000000", //10,000e18
       "--from",
       curveWhale,
+      "--unlocked",
     ],
     {
       stdio: "inherit",


### PR DESCRIPTION
This PR fixes the development deploy contract script `yarn workspace @ubiquity/contracts deploy:development` error:
```
----------------------------------------------------------------
Impersonating 'CURVE_WHALE' account
----------------------------------------------------------------
null
----------------------------------------------------------------
Sending 10,000 3CRV LP tokens to 'ADMIN_ADDRESS'
----------------------------------------------------------------
Error: 
Error accessing local wallet. Did you set a private key, mnemonic or keystore?
Run `cast send --help` or `forge create --help` and use the corresponding CLI
flag to set your key via:
--private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger.
Alternatively, if you're using a local node with unlocked accounts,
use the --unlocked flag and either set the `ETH_FROM` environment variable to the address
of the unlocked account you want to use, or provide the --from flag with the address directly.
----------------------------------------------------------------
Ending account impersonation
----------------------------------------------------------------
null
----------------------------------------------------------------
Running Solidity script
----------------------------------------------------------------

cast rpc anvil_impersonateAccount 0x4486083589A063ddEF47EE2E4467B5236C508fDe -r http://localhost:8545
cast send 0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490 "transfer(address, uint256)" 0xa18E35a6E821AaDC80AFD132FFa72879f999F2fc 10000000000000000000000 --from 0x4486083589A063ddEF47EE2E4467B5236C508fDe
```
