### PR TITLE
docs: set code coverage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build & Test](https://github.com/ubiquity/ubiquity-dollar/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/ubiquity/ubiquity-dollar/actions/workflows/build-and-test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/QuintusTheFifth/ubiquity-dollar/badge.svg?branch=development)](https://coveralls.io/github/QuintusTheFifth/ubiquity-dollar?branch=development)
+[![Coverage Status](https://coveralls.io/repos/github/ubiquity/ubiquity-dollar/badge.svg?branch=development)](https://coveralls.io/github/ubiquity/ubiquity-dollar?branch=development)
 # Ubiquity Dollar
 Introducing the flagship product of [Ubiquity DAO](https://ubq.fi/). The Ubiquity Dollar (uAD) is a collateralized stablecoin.
 - The deployed smart contracts can be found in the [docs](https://dao.ubq.fi/smart-contracts).


### PR DESCRIPTION
This PR sets the correct path to code coverage badge in the README file

