### PR TITLE
fix: remove unreachable return

### DIFF
--- a/packages/contracts/src/dollar/libraries/LibCurveDollarIncentive.sol
+++ b/packages/contracts/src/dollar/libraries/LibCurveDollarIncentive.sol
@@ -159,7 +159,6 @@ library LibCurveDollarIncentive {
         bytes16 res = _one.sub(curPrice.fromUInt()).mul(amount.fromUInt());
         // returns (1- TWAP_Price) * amount.
         return res.div(_one).toUInt();
-        LibTWAPOracle.update();
     }
 
     function _getTWAPPrice() internal view returns (uint256) {


### PR DESCRIPTION
This PR removes an unreachable return mentioned [here](https://github.com/ubiquity/ubiquity-dollar/issues/684#issuecomment-1597166172)