### PR TITLE
ci: exclude additional files in coverage

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -118,8 +118,3 @@ jobs:
         run: |
           echo "Error: test coverage decreased"
           exit 1
-
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v1
-        with:
-          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -92,7 +92,14 @@ jobs:
               --rc lcov_branch_coverage=1 \
               --remove merged-lcov.info \
               --output-file filtered-lcov.info \
-              "*node_modules*" "*test*" "*mock*" "*scripts*"
+                  "*node_modules*" \
+                  "*test*" \
+                  "*mock*" \
+                  "*scripts*" \
+                  "src/dollar/mocks/*" \
+                  "src/dollar/utils/*" \
+                  "src/ubiquistick/MockUBQmanager.sol" \
+                  "test/*" \
 
 
           # Generate summary


### PR DESCRIPTION
This PR filters additional folders in the coverage workflow (so that development and PR branches could compare the same files) and removes a coveralls step because it is handled [here](https://github.com/ubiquity/ubiquity-dollar/issues/482)