### PR TITLE
fix: check foundry builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,6 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly-31d6498c79af595577f200fc2136b31f43885397
-          
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-ed5eb9796aefe8cccc8d56676aa90ff68d7edfd4
+          version: nightly-31d6498c79af595577f200fc2136b31f43885397
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly-31d6498c79af595577f200fc2136b31f43885397
+          
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts


### PR DESCRIPTION
We'll keep an eye out on this was, the way they release (foundry), it broke the commit hash.

This PR only updates foundry's commit hash