### PR TITLE
refactor: pool facet cleanup

### DIFF
--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.19;
 import {LibUbiquityPool} from "../libraries/LibUbiquityPool.sol";
 import {Modifiers} from "../libraries/LibAppStorage.sol";
 import {IMetaPool} from "../interfaces/IMetaPool.sol";
-import "forge-std/console.sol";
 import "../interfaces/IUbiquityPool.sol";
 
 contract UbiquityPoolFacet is Modifiers, IUbiquityPool {
@@ -20,7 +19,6 @@ contract UbiquityPoolFacet is Modifiers, IUbiquityPool {
         uint256 collateralAmount,
         uint256 dollarOutMin
     ) external {
-        console.log("mintDollar");
         LibUbiquityPool.mintDollar(
             collateralAddress,
             collateralAmount,

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -298,7 +298,7 @@ contract UbiquityPoolFacetTest is DiamondSetup {
         vm.stopPrank();
     }
 
-    function collectRedemptionShouldWork() public {
+    function test_collectRedemptionShouldWork() public {
         MockERC20 collateral = new MockERC20("collateral", "collateral", 18);
         collateral.mint(fourthAccount, 10 ether);
         vm.prank(admin);


### PR DESCRIPTION
This PR:
- removes `console.log`
- add thes `test` prefix to the `collectRedemptionShouldWork()` method so that the test was actually run
