### PR TITLE
Ci/fix slither

### DIFF
--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -1,6 +1,12 @@
 name: Slither Analysis
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+      - main
+  pull_request:
+
 jobs:
   slither-analysis:
     name: Slither Analysis

--- a/packages/contracts/slither.config.json
+++ b/packages/contracts/slither.config.json
@@ -1,7 +1,7 @@
 {
   "exclude_informational": true,
   "exclude_low": true,
-  "detectors_to_exclude": "naming-conventions,different-pragma-directives-are-used,external-function,assembly,incorrect-equality,solc-version,unused-return",
+  "detectors_to_exclude": "naming-conventions,different-pragma-directives-are-used,external-function,assembly,incorrect-equality,solc-version,unused-return,cache-array-length",
   "exclude_medium": false,
   "exclude_high": false,
   "disable_color": false,


### PR DESCRIPTION
The latest slither release fails because of the newly introduced `cache-array-length` detector

More info [here](https://github.com/crytic/slither/issues/2017)

The `cache-array-length` has an [optimization](https://github.com/crytic/slither/wiki/Detector-Documentation#cache-array-length) severity and can be excluded for now