### PR TITLE
update foundry commit to monthly stable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-9aefa433dfa28dd74b83c83f7265c91f7506f4bc
+          version: nightly-cc5637a979050c39b3d06bc4cc6134f0591ee8d0
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts


### PR DESCRIPTION
Resolves #715 

This PR introduces monthly foundry commit hash for stability on our CI. it shouldn't break anymore