### PR TITLE
build: remove target from config

### DIFF
--- a/.github/ubiquibot-config.yml
+++ b/.github/ubiquibot-config.yml
@@ -5,36 +5,26 @@ time-labels:
 - name: 'Time: <1 Hour'
   weight: 0.125
   value: 3600
-  target: 'Price: 12.5+ USD'
 - name: 'Time: <1 Day'
   weight: 1
   value: 86400
-  target: 'Price: 100+ USD'
 - name: 'Time: <1 Week'
   weight: 2
   value: 604800
-  target: 'Price: 200+ USD'
 - name: 'Time: <2 Weeks'
   weight: 3
   value: 1209600
-  target: 'Price: 300+ USD'
 - name: 'Time: <1 Month'
   weight: 4
   value: 2592000
-  target: 'Price: 400+ USD'
 priority-labels:
 - name: 'Priority: 0 (Normal)'
   weight: 1
-  target: 'Price: 100+ USD'
 - name: 'Priority: 1 (Medium)'
   weight: 2
-  target: 'Price: 200+ USD'
 - name: 'Priority: 2 (High)'
   weight: 3
-  target: 'Price: 300+ USD'
 - name: 'Priority: 3 (Urgent)'
   weight: 4
-  target: 'Price: 400+ USD'
 - name: 'Priority: 4 (Emergency)'
   weight: 5
-  target: 'Price: 500+ USD'


### PR DESCRIPTION
This [PR](https://github.com/ubiquity/ubiquibot/pull/348/files) removes range labels hence we're free to remove all `target` properties from the bot's config
