### PR TITLE
fix: renamed CreditNFT to CreditNft

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -137,5 +137,6 @@
     "zozo",
     "UbiquiBot"
   ],
+  "flagWords":["creditNFT","CreditNFT"],
   "language": "en-US"
 }

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -37,6 +37,6 @@ Deploy script has been built on top of `forge create` and typescript to manage d
 # ARGUMENTS - Deploy Arguments which has been configured per smart contract. You can find them in each deploy script file.
 
 yarn workspace @ubiquity/contracts deploy DEPLOY_NAME ...ARGUMENTS
-# e.g. yarn workspace @ubiquity/contracts deploy CreditNFT --manager 0x4DA97a8b831C345dBe6d16FF7432DF2b7b776d98 --network mainnet
+# e.g. yarn workspace @ubiquity/contracts deploy CreditNft --manager 0x4DA97a8b831C345dBe6d16FF7432DF2b7b776d98 --network mainnet
 
 ```

--- a/packages/contracts/docs/src/README.md
+++ b/packages/contracts/docs/src/README.md
@@ -37,6 +37,6 @@ Deploy script has been built on top of `forge create` and typescript to manage d
 # ARGUMENTS - Deploy Arguments which has been configured per smart contract. You can find them in each deploy script file.
 
 yarn workspace @ubiquity/contracts deploy DEPLOY_NAME ...ARGUMENTS
-# e.g. yarn workspace @ubiquity/contracts deploy CreditNFT --manager 0x4DA97a8b831C345dBe6d16FF7432DF2b7b776d98 --network mainnet
+# e.g. yarn workspace @ubiquity/contracts deploy CreditNft --manager 0x4DA97a8b831C345dBe6d16FF7432DF2b7b776d98 --network mainnet
 
 ```

--- a/packages/contracts/docs/src/src/dollar/core/CreditNft.sol/contract.CreditNft.md
+++ b/packages/contracts/docs/src/src/dollar/core/CreditNft.sol/contract.CreditNft.md
@@ -84,7 +84,7 @@ function mintCreditNft(address recipient, uint256 amount, uint256 expiryBlockNum
 |----|----|-----------|
 |`recipient`|`address`|Address where to mint tokens|
 |`amount`|`uint256`|Amount of tokens to mint|
-|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNFTs to mint|
+|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNfts to mint|
 
 
 ### burnCreditNft
@@ -99,9 +99,9 @@ function burnCreditNft(address creditNftOwner, uint256 amount, uint256 expiryBlo
 
 |Name|Type|Description|
 |----|----|-----------|
-|`creditNftOwner`|`address`|Owner of those CreditNFTs|
+|`creditNftOwner`|`address`|Owner of those CreditNfts|
 |`amount`|`uint256`|Amount of tokens to burn|
-|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNFTs to burn|
+|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNfts to burn|
 
 
 ### updateTotalDebt

--- a/packages/contracts/docs/src/src/dollar/facets/CreditNftManagerFacet.sol/contract.CreditNftManagerFacet.md
+++ b/packages/contracts/docs/src/src/dollar/facets/CreditNftManagerFacet.sol/contract.CreditNftManagerFacet.md
@@ -14,7 +14,7 @@ Allows users to:
 
 
 ## Functions
-### setExpiredCreditNFTConversionRate
+### setExpiredCreditNftConversionRate
 
 Credit NFT to Governance conversion rate
 
@@ -23,7 +23,7 @@ Governance tokens using `rate` conversion rate
 
 
 ```solidity
-function setExpiredCreditNFTConversionRate(uint256 rate) external onlyCreditNFTManager;
+function setExpiredCreditNftConversionRate(uint256 rate) external onlyCreditNftManager;
 ```
 **Parameters**
 
@@ -32,13 +32,13 @@ function setExpiredCreditNFTConversionRate(uint256 rate) external onlyCreditNFTM
 |`rate`|`uint256`|Credit NFT to Governance tokens conversion rate|
 
 
-### expiredCreditNFTConversionRate
+### expiredCreditNftConversionRate
 
 Returns Credit NFT to Governance conversion rate
 
 
 ```solidity
-function expiredCreditNFTConversionRate() external view returns (uint256);
+function expiredCreditNftConversionRate() external view returns (uint256);
 ```
 **Returns**
 
@@ -47,28 +47,28 @@ function expiredCreditNFTConversionRate() external view returns (uint256);
 |`<none>`|`uint256`|Conversion rate|
 
 
-### setCreditNFTLength
+### setCreditNftLength
 
 Sets Credit NFT block lifespan
 
 
 ```solidity
-function setCreditNFTLength(uint256 _creditNFTLengthBlocks) external onlyCreditNFTManager;
+function setCreditNftLength(uint256 _creditNftLengthBlocks) external onlyCreditNftManager;
 ```
 **Parameters**
 
 |Name|Type|Description|
 |----|----|-----------|
-|`_creditNFTLengthBlocks`|`uint256`|The number of blocks during which Credit NFTs can be redeemed for Dollars|
+|`_creditNftLengthBlocks`|`uint256`|The number of blocks during which Credit NFTs can be redeemed for Dollars|
 
 
-### creditNFTLengthBlocks
+### creditNftLengthBlocks
 
 Returns Credit NFT block lifespan
 
 
 ```solidity
-function creditNFTLengthBlocks() external view returns (uint256);
+function creditNftLengthBlocks() external view returns (uint256);
 ```
 **Returns**
 
@@ -123,13 +123,13 @@ function exchangeDollarsForCredit(uint256 amount) external returns (uint256);
 |`<none>`|`uint256`|Amount of Credits minted|
 
 
-### getCreditNFTReturnedForDollars
+### getCreditNftReturnedForDollars
 
 Returns amount of Credit NFTs to be minted for the `amount` of Dollars to burn
 
 
 ```solidity
-function getCreditNFTReturnedForDollars(uint256 amount) external view returns (uint256);
+function getCreditNftReturnedForDollars(uint256 amount) external view returns (uint256);
 ```
 **Parameters**
 
@@ -220,13 +220,13 @@ function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] 
 |`<none>`|`bytes4`|`bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` if transfer is allowed|
 
 
-### burnExpiredCreditNFTForGovernance
+### burnExpiredCreditNftForGovernance
 
-Burns expired Credit NFTs for Governance tokens at `expiredCreditNFTConversionRate` rate
+Burns expired Credit NFTs for Governance tokens at `expiredCreditNftConversionRate` rate
 
 
 ```solidity
-function burnExpiredCreditNFTForGovernance(uint256 id, uint256 amount) public returns (uint256 governanceAmount);
+function burnExpiredCreditNftForGovernance(uint256 id, uint256 amount) public returns (uint256 governanceAmount);
 ```
 **Parameters**
 
@@ -242,7 +242,7 @@ function burnExpiredCreditNFTForGovernance(uint256 id, uint256 amount) public re
 |`governanceAmount`|`uint256`|Amount of Governance tokens minted to Credit NFT holder|
 
 
-### burnCreditNFTForCredit
+### burnCreditNftForCredit
 
 TODO: Should we leave it ?
 
@@ -250,7 +250,7 @@ Burns Credit NFTs for Credit tokens
 
 
 ```solidity
-function burnCreditNFTForCredit(uint256 id, uint256 amount) public returns (uint256);
+function burnCreditNftForCredit(uint256 id, uint256 amount) public returns (uint256);
 ```
 **Parameters**
 

--- a/packages/contracts/docs/src/src/dollar/facets/ManagerFacet.sol/contract.ManagerFacet.md
+++ b/packages/contracts/docs/src/src/dollar/facets/ManagerFacet.sol/contract.ManagerFacet.md
@@ -435,13 +435,13 @@ function creditCalculatorAddress() external view returns (address);
 |`<none>`|`address`|Credit redemption calculator address|
 
 
-### creditNFTCalculatorAddress
+### creditNftCalculatorAddress
 
 Returns Credit NFT redemption calculator address
 
 
 ```solidity
-function creditNFTCalculatorAddress() external view returns (address);
+function creditNftCalculatorAddress() external view returns (address);
 ```
 **Returns**
 

--- a/packages/contracts/docs/src/src/dollar/interfaces/ICreditNft.sol/interface.ICreditNft.md
+++ b/packages/contracts/docs/src/src/dollar/interfaces/ICreditNft.sol/interface.ICreditNft.md
@@ -33,9 +33,9 @@ function burnCreditNft(address creditNftOwner, uint256 amount, uint256 expiryBlo
 
 |Name|Type|Description|
 |----|----|-----------|
-|`creditNftOwner`|`address`|Owner of those CreditNFTs|
+|`creditNftOwner`|`address`|Owner of those CreditNfts|
 |`amount`|`uint256`|Amount of tokens to burn|
-|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNFTs to burn|
+|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNfts to burn|
 
 
 ### mintCreditNft
@@ -52,7 +52,7 @@ function mintCreditNft(address recipient, uint256 amount, uint256 expiryBlockNum
 |----|----|-----------|
 |`recipient`|`address`|Address where to mint tokens|
 |`amount`|`uint256`|Amount of tokens to mint|
-|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNFTs to mint|
+|`expiryBlockNumber`|`uint256`|Expiration block number of the CreditNfts to mint|
 
 
 ### getTotalOutstandingDebt

--- a/packages/contracts/docs/src/src/dollar/libraries/LibAppStorage.sol/contract.Modifiers.md
+++ b/packages/contracts/docs/src/src/dollar/libraries/LibAppStorage.sol/contract.Modifiers.md
@@ -41,13 +41,13 @@ Checks that method is called by a contract owner
 modifier onlyOwner();
 ```
 
-### onlyCreditNFTManager
+### onlyCreditNftManager
 
 Checks that method is called by address with the `CREDIT_NFT_MANAGER_ROLE` role
 
 
 ```solidity
-modifier onlyCreditNFTManager();
+modifier onlyCreditNftManager();
 ```
 
 ### onlyAdmin

--- a/packages/contracts/docs/src/src/dollar/libraries/LibAppStorage.sol/struct.AppStorage.md
+++ b/packages/contracts/docs/src/src/dollar/libraries/LibAppStorage.sol/struct.AppStorage.md
@@ -9,7 +9,7 @@ struct AppStorage {
     uint256 reentrancyStatus;
     address dollarTokenAddress;
     address creditNftAddress;
-    address creditNFTCalculatorAddress;
+    address creditNftCalculatorAddress;
     address dollarMintCalculatorAddress;
     address stakingShareAddress;
     address stakingContractAddress;

--- a/packages/contracts/docs/src/src/dollar/libraries/LibCreditNftManager.sol/library.LibCreditNftManager.md
+++ b/packages/contracts/docs/src/src/dollar/libraries/LibCreditNftManager.sol/library.LibCreditNftManager.md
@@ -22,28 +22,28 @@ bytes32 constant CREDIT_NFT_MANAGER_STORAGE_SLOT =
 
 
 ## Functions
-### creditNFTStorage
+### creditNftStorage
 
 Returns struct used as a storage for this library
 
 
 ```solidity
-function creditNFTStorage() internal pure returns (CreditNFTMgrData storage l);
+function creditNftStorage() internal pure returns (CreditNftMgrData storage l);
 ```
 **Returns**
 
 |Name|Type|Description|
 |----|----|-----------|
-|`l`|`CreditNFTMgrData`|Struct used as a storage|
+|`l`|`CreditNftMgrData`|Struct used as a storage|
 
 
-### expiredCreditNFTConversionRate
+### expiredCreditNftConversionRate
 
 Returns Credit NFT to Governance conversion rate
 
 
 ```solidity
-function expiredCreditNFTConversionRate() internal view returns (uint256);
+function expiredCreditNftConversionRate() internal view returns (uint256);
 ```
 **Returns**
 
@@ -52,7 +52,7 @@ function expiredCreditNFTConversionRate() internal view returns (uint256);
 |`<none>`|`uint256`|Conversion rate|
 
 
-### setExpiredCreditNFTConversionRate
+### setExpiredCreditNftConversionRate
 
 Credit NFT to Governance conversion rate
 
@@ -61,7 +61,7 @@ Governance tokens using `rate` conversion rate
 
 
 ```solidity
-function setExpiredCreditNFTConversionRate(uint256 rate) internal;
+function setExpiredCreditNftConversionRate(uint256 rate) internal;
 ```
 **Parameters**
 
@@ -70,28 +70,28 @@ function setExpiredCreditNFTConversionRate(uint256 rate) internal;
 |`rate`|`uint256`|Credit NFT to Governance tokens conversion rate|
 
 
-### setCreditNFTLength
+### setCreditNftLength
 
 Sets Credit NFT block lifespan
 
 
 ```solidity
-function setCreditNFTLength(uint256 _creditNFTLengthBlocks) internal;
+function setCreditNftLength(uint256 _creditNftLengthBlocks) internal;
 ```
 **Parameters**
 
 |Name|Type|Description|
 |----|----|-----------|
-|`_creditNFTLengthBlocks`|`uint256`|The number of blocks during which Credit NFTs can be redeemed for Dollars|
+|`_creditNftLengthBlocks`|`uint256`|The number of blocks during which Credit NFTs can be redeemed for Dollars|
 
 
-### creditNFTLengthBlocks
+### creditNftLengthBlocks
 
 Returns Credit NFT block lifespan
 
 
 ```solidity
-function creditNFTLengthBlocks() internal view returns (uint256);
+function creditNftLengthBlocks() internal view returns (uint256);
 ```
 **Returns**
 
@@ -146,13 +146,13 @@ function exchangeDollarsForCredit(uint256 amount) internal returns (uint256);
 |`<none>`|`uint256`|Amount of Credits minted|
 
 
-### getCreditNFTReturnedForDollars
+### getCreditNftReturnedForDollars
 
 Returns amount of Credit NFTs to be minted for the `amount` of Dollars to burn
 
 
 ```solidity
-function getCreditNFTReturnedForDollars(uint256 amount) internal view returns (uint256);
+function getCreditNftReturnedForDollars(uint256 amount) internal view returns (uint256);
 ```
 **Parameters**
 
@@ -220,13 +220,13 @@ function onERC1155Received(address operator, address, uint256, uint256, bytes ca
 |`<none>`|`bytes4`|`bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` if transfer is allowed|
 
 
-### burnExpiredCreditNFTForGovernance
+### burnExpiredCreditNftForGovernance
 
-Burns expired Credit NFTs for Governance tokens at `expiredCreditNFTConversionRate` rate
+Burns expired Credit NFTs for Governance tokens at `expiredCreditNftConversionRate` rate
 
 
 ```solidity
-function burnExpiredCreditNFTForGovernance(uint256 id, uint256 amount) public returns (uint256 governanceAmount);
+function burnExpiredCreditNftForGovernance(uint256 id, uint256 amount) public returns (uint256 governanceAmount);
 ```
 **Parameters**
 
@@ -242,7 +242,7 @@ function burnExpiredCreditNFTForGovernance(uint256 id, uint256 amount) public re
 |`governanceAmount`|`uint256`|Amount of Governance tokens minted to Credit NFT holder|
 
 
-### burnCreditNFTForCredit
+### burnCreditNftForCredit
 
 TODO: Should we leave it ?
 
@@ -250,7 +250,7 @@ Burns Credit NFTs for Credit tokens
 
 
 ```solidity
-function burnCreditNFTForCredit(uint256 id, uint256 amount) public returns (uint256);
+function burnCreditNftForCredit(uint256 id, uint256 amount) public returns (uint256);
 ```
 **Parameters**
 
@@ -287,13 +287,13 @@ function burnCreditTokensForDollars(uint256 amount) public returns (uint256);
 |`<none>`|`uint256`|Amount of unredeemed Credits|
 
 
-### redeemCreditNFT
+### redeemCreditNft
 
 Burns Credit NFTs for Dollars when Dollar price > 1$
 
 
 ```solidity
-function redeemCreditNFT(uint256 id, uint256 amount) public returns (uint256);
+function redeemCreditNft(uint256 id, uint256 amount) public returns (uint256);
 ```
 **Parameters**
 
@@ -324,33 +324,33 @@ function mintClaimableDollars() public;
 ```
 
 ## Events
-### ExpiredCreditNFTConversionRateChanged
+### ExpiredCreditNftConversionRateChanged
 Emitted when Credit NFT to Governance conversion rate was updated
 
 
 ```solidity
-event ExpiredCreditNFTConversionRateChanged(uint256 newRate, uint256 previousRate);
+event ExpiredCreditNftConversionRateChanged(uint256 newRate, uint256 previousRate);
 ```
 
-### CreditNFTLengthChanged
+### CreditNftLengthChanged
 Emitted when Credit NFT block expiration length was updated
 
 
 ```solidity
-event CreditNFTLengthChanged(uint256 newCreditNFTLengthBlocks, uint256 previousCreditNFTLengthBlocks);
+event CreditNftLengthChanged(uint256 newCreditNftLengthBlocks, uint256 previousCreditNftLengthBlocks);
 ```
 
 ## Structs
-### CreditNFTMgrData
+### CreditNftMgrData
 Struct used as a storage for the current library
 
 
 ```solidity
-struct CreditNFTMgrData {
+struct CreditNftMgrData {
     uint256 dollarsMintedThisCycle;
     uint256 blockHeightDebt;
-    uint256 creditNFTLengthBlocks;
-    uint256 expiredCreditNFTConversionRate;
+    uint256 creditNftLengthBlocks;
+    uint256 expiredCreditNftConversionRate;
     bool debtCycle;
 }
 ```

--- a/packages/contracts/docs/src/src/dollar/libraries/LibCreditNftRedemptionCalculator.sol/library.LibCreditNftRedemptionCalculator.md
+++ b/packages/contracts/docs/src/src/dollar/libraries/LibCreditNftRedemptionCalculator.sol/library.LibCreditNftRedemptionCalculator.md
@@ -5,13 +5,13 @@ Library for calculating amount of Credit NFTs to mint on Dollars burn
 
 
 ## Functions
-### getCreditNFTAmount
+### getCreditNftAmount
 
 Returns Credit NFT amount minted for `dollarsToBurn` amount of Dollars to burn
 
 
 ```solidity
-function getCreditNFTAmount(uint256 dollarsToBurn) internal view returns (uint256);
+function getCreditNftAmount(uint256 dollarsToBurn) internal view returns (uint256);
 ```
 **Parameters**
 

--- a/packages/contracts/docs/src/src/dollar/upgradeInitializers/DiamondInit.sol/contract.DiamondInit.md
+++ b/packages/contracts/docs/src/src/dollar/upgradeInitializers/DiamondInit.sol/contract.DiamondInit.md
@@ -44,7 +44,7 @@ struct Args {
     uint256[] amounts;
     uint256[] stakingShareIDs;
     uint256 governancePerBlock;
-    uint256 creditNFTLengthBlocks;
+    uint256 creditNftLengthBlocks;
 }
 ```
 

--- a/packages/contracts/scripts/deploy/dollar/solidityScripting/01_Diamond.s.sol
+++ b/packages/contracts/scripts/deploy/dollar/solidityScripting/01_Diamond.s.sol
@@ -42,8 +42,8 @@ contract DiamondScript is Constants {
     bytes4[] selectorsOfStakingFacet;
     bytes4[] selectorsOfStakingFormulasFacet;
 
-    bytes4[] selectorsOfCreditNFTManagerFacet;
-    bytes4[] selectorsOfCreditNFTRedemptionCalculatorFacet;
+    bytes4[] selectorsOfCreditNftManagerFacet;
+    bytes4[] selectorsOfCreditNftRedemptionCalculatorFacet;
     bytes4[] selectorsOfCreditRedemptionCalculatorFacet;
 
     bytes4[] selectorsOfDollarMintCalculatorFacet;
@@ -56,7 +56,7 @@ contract DiamondScript is Constants {
     ManagerFacet managerFacet;
     // facet through diamond address
     ManagerFacet IManager;
-    AccessControlFacet IAccessCtrl;
+    AccessControlFacet IAccessControl;
     DiamondInit dInit;
     // actual implementation of facets
     AccessControlFacet accessControlFacet;
@@ -66,8 +66,8 @@ contract DiamondScript is Constants {
     StakingFacet stakingFacet;
     StakingFormulasFacet stakingFormulasFacet;
 
-    CreditNftManagerFacet creditNFTManagerFacet;
-    CreditNftRedemptionCalculatorFacet creditNFTRedemptionCalculatorFacet;
+    CreditNftManagerFacet creditNftManagerFacet;
+    CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculatorFacet;
     CreditRedemptionCalculatorFacet creditRedemptionCalculatorFacet;
 
     DollarMintCalculatorFacet dollarMintCalculatorFacet;
@@ -90,8 +90,8 @@ contract DiamondScript is Constants {
         stakingFacet = new StakingFacet();
         stakingFormulasFacet = new StakingFormulasFacet();
 
-        creditNFTManagerFacet = new CreditNftManagerFacet();
-        creditNFTRedemptionCalculatorFacet = new CreditNftRedemptionCalculatorFacet();
+        creditNftManagerFacet = new CreditNftManagerFacet();
+        creditNftRedemptionCalculatorFacet = new CreditNftRedemptionCalculatorFacet();
         creditRedemptionCalculatorFacet = new CreditRedemptionCalculatorFacet();
 
         dollarMintCalculatorFacet = new DollarMintCalculatorFacet();
@@ -109,8 +109,8 @@ contract DiamondScript is Constants {
             "ChefFacet",
             "StakingFacet",
             "StakingFormulasFacet",
-            "CreditNFTManagerFacet",
-            "CreditNFTRedemptionCalculatorFacet",
+            "CreditNftManagerFacet",
+            "CreditNftRedemptionCalculatorFacet",
             "CreditRedemptionCalculatorFacet",
             "DollarMintCalculatorFacet",
             "DollarMintExcessFacet"
@@ -122,7 +122,7 @@ contract DiamondScript is Constants {
             amounts: new uint256[](0),
             stakingShareIDs: new uint256[](0),
             governancePerBlock: 10e18,
-            creditNFTLengthBlocks: 100
+            creditNftLengthBlocks: 100
         });
         // diamond arguments
         DiamondArgs memory _args = DiamondArgs({
@@ -139,7 +139,7 @@ contract DiamondScript is Constants {
 
         diamond = new Diamond(_args, cuts);
         IManager = ManagerFacet(address(diamond));
-        IAccessCtrl = AccessControlFacet(address(diamond));
+        IAccessControl = AccessControlFacet(address(diamond));
         StakingFacet IStakingFacet = StakingFacet(address(diamond));
         IStakingFacet.setBlockCountInAWeek(420);
         vm.stopBroadcast();
@@ -223,16 +223,16 @@ contract DiamondScript is Constants {
         );
         cuts[10] = (
             IDiamondCut.FacetCut({
-                facetAddress: address(creditNFTManagerFacet),
+                facetAddress: address(creditNftManagerFacet),
                 action: IDiamondCut.FacetCutAction.Add,
-                functionSelectors: selectorsOfCreditNFTManagerFacet
+                functionSelectors: selectorsOfCreditNftManagerFacet
             })
         );
         cuts[11] = (
             IDiamondCut.FacetCut({
-                facetAddress: address(creditNFTRedemptionCalculatorFacet),
+                facetAddress: address(creditNftRedemptionCalculatorFacet),
                 action: IDiamondCut.FacetCutAction.Add,
-                functionSelectors: selectorsOfCreditNFTRedemptionCalculatorFacet
+                functionSelectors: selectorsOfCreditNftRedemptionCalculatorFacet
             })
         );
         cuts[12] = (
@@ -335,7 +335,7 @@ contract DiamondScript is Constants {
             managerFacet.creditCalculatorAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.creditNFTCalculatorAddress.selector
+            managerFacet.creditNftCalculatorAddress.selector
         );
         selectorsOfManagerFacet.push(
             managerFacet.dollarMintCalculatorAddress.selector
@@ -451,55 +451,55 @@ contract DiamondScript is Constants {
         );
 
         // Credit facets
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.creditNFTLengthBlocks.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.creditNftLengthBlocks.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.expiredCreditNFTConversionRate.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.expiredCreditNftConversionRate.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.setExpiredCreditNFTConversionRate.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.setExpiredCreditNftConversionRate.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.setCreditNFTLength.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.setCreditNftLength.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.exchangeDollarsForCreditNft.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.exchangeDollarsForCreditNft.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.exchangeDollarsForCredit.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.exchangeDollarsForCredit.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.getCreditNFTReturnedForDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.getCreditNftReturnedForDollars.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.getCreditReturnedForDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.getCreditReturnedForDollars.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.onERC1155Received.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.onERC1155Received.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.onERC1155BatchReceived.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.onERC1155BatchReceived.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.burnExpiredCreditNFTForGovernance.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.burnExpiredCreditNftForGovernance.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.burnCreditNFTForCredit.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.burnCreditNftForCredit.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.burnCreditTokensForDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.burnCreditTokensForDollars.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.redeemCreditNft.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.redeemCreditNft.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.mintClaimableDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.mintClaimableDollars.selector
         );
 
         // Credit NFT Redemption Calculator
-        selectorsOfCreditNFTRedemptionCalculatorFacet.push(
-            creditNFTRedemptionCalculatorFacet.getCreditNftAmount.selector
+        selectorsOfCreditNftRedemptionCalculatorFacet.push(
+            creditNftRedemptionCalculatorFacet.getCreditNftAmount.selector
         );
 
         // Credit Redemption Calculator

--- a/packages/contracts/scripts/deploy/dollar/solidityScripting/02_UbiquityDollarToken.s.sol
+++ b/packages/contracts/scripts/deploy/dollar/solidityScripting/02_UbiquityDollarToken.s.sol
@@ -14,8 +14,8 @@ contract DollarScript is DiamondScript {
 
         dollar = new UbiquityDollarToken(address(diamond));
         IManager.setDollarTokenAddress(address(dollar));
-        IAccessCtrl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(DOLLAR_TOKEN_BURNER_ROLE, address(diamond));
+        IAccessControl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(DOLLAR_TOKEN_BURNER_ROLE, address(diamond));
 
         dollar.mint(address(diamond), 10000e18);
         uint256 adminBal = IERC20(curve3PoolToken).balanceOf(admin);

--- a/packages/contracts/scripts/deploy/dollar/solidityScripting/03_UbiquityGovernanceToken.s.sol
+++ b/packages/contracts/scripts/deploy/dollar/solidityScripting/03_UbiquityGovernanceToken.s.sol
@@ -14,8 +14,8 @@ contract GovernanceScript is DollarScript {
 
         IManager.setGovernanceTokenAddress(address(governance));
         // grant diamond token admin rights
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
 
         vm.stopBroadcast();
     }

--- a/packages/contracts/scripts/deploy/dollar/solidityScripting/04_UbiquityCredit.s.sol
+++ b/packages/contracts/scripts/deploy/dollar/solidityScripting/04_UbiquityCredit.s.sol
@@ -13,9 +13,9 @@ contract CreditScript is GovernanceScript {
         UbiquityCreditToken credit = new UbiquityCreditToken(address(diamond));
         IManager.setCreditTokenAddress(address(credit));
 
-        IAccessCtrl.grantRole(CREDIT_TOKEN_MINTER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(CREDIT_TOKEN_BURNER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        IAccessControl.grantRole(CREDIT_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(CREDIT_TOKEN_BURNER_ROLE, address(diamond));
+        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
 
         CreditNft creditNft = new CreditNft(address(diamond));
         IManager.setCreditNftAddress(address(creditNft));

--- a/packages/contracts/scripts/deploy/dollar/solidityScripting/05_StakingShare.s.sol
+++ b/packages/contracts/scripts/deploy/dollar/solidityScripting/05_StakingShare.s.sol
@@ -9,7 +9,7 @@ contract StakingShareScript is CreditScript {
         vm.startBroadcast(deployerPrivateKey);
 
         // grant diamond token minter rights
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
         // add staking shares
         string
             memory uri = "https://bafybeifibz4fhk4yag5reupmgh5cdbm2oladke4zfd7ldyw7avgipocpmy.ipfs.infura-ipfs.io/";

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -232,7 +232,7 @@ async function deployDiamond() {
       amounts: [0],
       stakingShareIDs: [0],
       governancePerBlock: ethers.utils.parseEther("10"),
-      creditNFTLengthBlocks: 100,
+      creditNftLengthBlocks: 100,
     },
   ];
   const functionCall = diamondInitInstance.interface.encodeFunctionData("init", initArgs);

--- a/packages/contracts/src/dollar/core/CreditClock.sol
+++ b/packages/contracts/src/dollar/core/CreditClock.sol
@@ -13,7 +13,7 @@ contract CreditClock {
     using ABDKMathQuad for bytes16;
 
     /// @notice Access control contract
-    IAccessControl public accessCtrl;
+    IAccessControl public accessControl;
 
     /// @notice ABDKMathQuad with value of 1.
     bytes16 private immutable one = uint256(1).fromUInt();
@@ -37,7 +37,7 @@ contract CreditClock {
     /// @notice Modifier checks that the method is called by a user with the "Incentive manager" role
     modifier onlyAdmin() {
         require(
-            accessCtrl.hasRole(INCENTIVE_MANAGER_ROLE, msg.sender),
+            accessControl.hasRole(INCENTIVE_MANAGER_ROLE, msg.sender),
             "CreditClock: not admin"
         );
         _;
@@ -54,7 +54,7 @@ contract CreditClock {
         bytes16 _rateStartValue,
         bytes16 _ratePerBlock
     ) {
-        accessCtrl = IAccessControl(_manager);
+        accessControl = IAccessControl(_manager);
         rateStartBlock = block.number;
         rateStartValue = _rateStartValue;
         ratePerBlock = _ratePerBlock;
@@ -67,7 +67,7 @@ contract CreditClock {
      * @param _manager New manager address
      */
     function setManager(address _manager) external onlyAdmin {
-        accessCtrl = IAccessControl(_manager);
+        accessControl = IAccessControl(_manager);
     }
 
     /**
@@ -75,7 +75,7 @@ contract CreditClock {
      * @return Manager address
      */
     function getManager() external view returns (address) {
-        return address(accessCtrl);
+        return address(accessControl);
     }
 
     /**

--- a/packages/contracts/src/dollar/core/CreditNft.sol
+++ b/packages/contracts/src/dollar/core/CreditNft.sol
@@ -44,7 +44,7 @@ contract CreditNft is ERC1155Ubiquity, ICreditNft {
     /// @notice Modifier checks that the method is called by a user with the "CreditNft manager" role
     modifier onlyCreditNftManager() {
         require(
-            accessCtrl.hasRole(CREDIT_NFT_MANAGER_ROLE, msg.sender),
+            accessControl.hasRole(CREDIT_NFT_MANAGER_ROLE, msg.sender),
             "Caller is not a CreditNft manager"
         );
         _;
@@ -63,7 +63,7 @@ contract CreditNft is ERC1155Ubiquity, ICreditNft {
      * @notice Mint an `amount` of CreditNfts expiring at `expiryBlockNumber` for a certain `recipient`
      * @param recipient Address where to mint tokens
      * @param amount Amount of tokens to mint
-     * @param expiryBlockNumber Expiration block number of the CreditNFTs to mint
+     * @param expiryBlockNumber Expiration block number of the CreditNfts to mint
      */
     function mintCreditNft(
         address recipient,
@@ -86,9 +86,9 @@ contract CreditNft is ERC1155Ubiquity, ICreditNft {
 
     /**
      * @notice Burns an `amount` of CreditNfts expiring at `expiryBlockNumber` from `creditNftOwner` balance
-     * @param creditNftOwner Owner of those CreditNFTs
+     * @param creditNftOwner Owner of those CreditNfts
      * @param amount Amount of tokens to burn
-     * @param expiryBlockNumber Expiration block number of the CreditNFTs to burn
+     * @param expiryBlockNumber Expiration block number of the CreditNfts to burn
      */
     function burnCreditNft(
         address creditNftOwner,

--- a/packages/contracts/src/dollar/core/ERC1155Ubiquity.sol
+++ b/packages/contracts/src/dollar/core/ERC1155Ubiquity.sol
@@ -20,7 +20,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
     using SafeAddArray for uint256[];
 
     /// @notice Access control interface
-    IAccessControl public accessCtrl;
+    IAccessControl public accessControl;
 
     /// @notice Mapping from account to array of token ids held by the account
     mapping(address => uint256[]) public holderBalances;
@@ -33,7 +33,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
     /// @notice Modifier checks that the method is called by a user with the "Governance minter" role
     modifier onlyMinter() virtual {
         require(
-            accessCtrl.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, msg.sender),
+            accessControl.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, msg.sender),
             "ERC1155Ubiquity: not minter"
         );
         _;
@@ -42,7 +42,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
     /// @notice Modifier checks that the method is called by a user with the "Governance burner" role
     modifier onlyBurner() virtual {
         require(
-            accessCtrl.hasRole(GOVERNANCE_TOKEN_BURNER_ROLE, msg.sender),
+            accessControl.hasRole(GOVERNANCE_TOKEN_BURNER_ROLE, msg.sender),
             "ERC1155Ubiquity: not burner"
         );
         _;
@@ -51,7 +51,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
     /// @notice Modifier checks that the method is called by a user with the "Pauser" role
     modifier onlyPauser() virtual {
         require(
-            accessCtrl.hasRole(PAUSER_ROLE, msg.sender),
+            accessControl.hasRole(PAUSER_ROLE, msg.sender),
             "ERC1155Ubiquity: not pauser"
         );
         _;
@@ -60,7 +60,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
     /// @notice Modifier checks that the method is called by a user with the "Admin" role
     modifier onlyAdmin() {
         require(
-            accessCtrl.hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            accessControl.hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
             "ERC20Ubiquity: not admin"
         );
         _;
@@ -72,7 +72,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
      * @param uri Base URI
      */
     constructor(address _manager, string memory uri) ERC1155(uri) {
-        accessCtrl = IAccessControl(_manager);
+        accessControl = IAccessControl(_manager);
     }
 
     /**
@@ -80,7 +80,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
      * @return Access control address
      */
     function getManager() external view returns (address) {
-        return address(accessCtrl);
+        return address(accessControl);
     }
 
     /**
@@ -88,7 +88,7 @@ contract ERC1155Ubiquity is ERC1155, ERC1155Burnable, ERC1155Pausable {
      * @param _manager New access control address
      */
     function setManager(address _manager) external onlyAdmin {
-        accessCtrl = IAccessControl(_manager);
+        accessControl = IAccessControl(_manager);
     }
 
     /**

--- a/packages/contracts/src/dollar/core/ERC20Ubiquity.sol
+++ b/packages/contracts/src/dollar/core/ERC20Ubiquity.sol
@@ -19,12 +19,12 @@ abstract contract ERC20Ubiquity is ERC20Permit, ERC20Pausable, IERC20Ubiquity {
     string private _symbol;
 
     /// @notice Access control interface
-    IAccessControl public accessCtrl;
+    IAccessControl public accessControl;
 
     /// @notice Modifier checks that the method is called by a user with the "pauser" role
     modifier onlyPauser() {
         require(
-            accessCtrl.hasRole(PAUSER_ROLE, msg.sender),
+            accessControl.hasRole(PAUSER_ROLE, msg.sender),
             "ERC20Ubiquity: not pauser"
         );
         _;
@@ -33,7 +33,7 @@ abstract contract ERC20Ubiquity is ERC20Permit, ERC20Pausable, IERC20Ubiquity {
     /// @notice Modifier checks that the method is called by a user with the "admin" role
     modifier onlyAdmin() {
         require(
-            accessCtrl.hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            accessControl.hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
             "ERC20Ubiquity: not admin"
         );
         _;
@@ -51,7 +51,7 @@ abstract contract ERC20Ubiquity is ERC20Permit, ERC20Pausable, IERC20Ubiquity {
         string memory symbol_
     ) ERC20(name_, symbol_) ERC20Permit(name_) {
         _symbol = symbol_;
-        accessCtrl = IAccessControl(_manager);
+        accessControl = IAccessControl(_manager);
     }
 
     /**
@@ -75,7 +75,7 @@ abstract contract ERC20Ubiquity is ERC20Permit, ERC20Pausable, IERC20Ubiquity {
      * @return Access control address
      */
     function getManager() external view returns (address) {
-        return address(accessCtrl);
+        return address(accessControl);
     }
 
     /**
@@ -83,7 +83,7 @@ abstract contract ERC20Ubiquity is ERC20Permit, ERC20Pausable, IERC20Ubiquity {
      * @param _manager New access control address
      */
     function setManager(address _manager) external onlyAdmin {
-        accessCtrl = IAccessControl(_manager);
+        accessControl = IAccessControl(_manager);
     }
 
     /// @notice Pauses all token transfers

--- a/packages/contracts/src/dollar/core/StakingShare.sol
+++ b/packages/contracts/src/dollar/core/StakingShare.sol
@@ -40,7 +40,7 @@ contract StakingShare is ERC1155Ubiquity, ERC1155URIStorage {
     /// @notice Modifier checks that the method is called by a user with the "Staking share minter" role
     modifier onlyMinter() override {
         require(
-            accessCtrl.hasRole(STAKING_SHARE_MINTER_ROLE, msg.sender),
+            accessControl.hasRole(STAKING_SHARE_MINTER_ROLE, msg.sender),
             "Staking Share: not minter"
         );
         _;
@@ -49,7 +49,7 @@ contract StakingShare is ERC1155Ubiquity, ERC1155URIStorage {
     /// @notice Modifier checks that the method is called by a user with the "Staking share burner" role
     modifier onlyBurner() override {
         require(
-            accessCtrl.hasRole(STAKING_SHARE_BURNER_ROLE, msg.sender),
+            accessControl.hasRole(STAKING_SHARE_BURNER_ROLE, msg.sender),
             "Staking Share: not burner"
         );
         _;
@@ -58,7 +58,7 @@ contract StakingShare is ERC1155Ubiquity, ERC1155URIStorage {
     /// @notice Modifier checks that the method is called by a user with the "Pauser" role
     modifier onlyPauser() override {
         require(
-            accessCtrl.hasRole(PAUSER_ROLE, msg.sender),
+            accessControl.hasRole(PAUSER_ROLE, msg.sender),
             "Staking Share: not pauser"
         );
         _;

--- a/packages/contracts/src/dollar/core/UbiquityCreditToken.sol
+++ b/packages/contracts/src/dollar/core/UbiquityCreditToken.sol
@@ -26,7 +26,7 @@ contract UbiquityCreditToken is ERC20Ubiquity {
     /// @notice Modifier checks that the method is called by a user with the "Credit minter" role
     modifier onlyCreditMinter() {
         require(
-            accessCtrl.hasRole(CREDIT_TOKEN_MINTER_ROLE, msg.sender),
+            accessControl.hasRole(CREDIT_TOKEN_MINTER_ROLE, msg.sender),
             "Credit token: not minter"
         );
         _;
@@ -35,7 +35,7 @@ contract UbiquityCreditToken is ERC20Ubiquity {
     /// @notice Modifier checks that the method is called by a user with the "Credit burner" role
     modifier onlyCreditBurner() {
         require(
-            accessCtrl.hasRole(CREDIT_TOKEN_BURNER_ROLE, msg.sender),
+            accessControl.hasRole(CREDIT_TOKEN_BURNER_ROLE, msg.sender),
             "Credit token: not burner"
         );
         _;
@@ -47,7 +47,7 @@ contract UbiquityCreditToken is ERC20Ubiquity {
      * @dev CREDIT_TOKEN_MINTER_ROLE access control role is required to call this function
      */
     function raiseCapital(uint256 amount) external {
-        address treasuryAddress = ManagerFacet(address(accessCtrl))
+        address treasuryAddress = ManagerFacet(address(accessControl))
             .treasuryAddress();
         mint(treasuryAddress, amount);
     }

--- a/packages/contracts/src/dollar/core/UbiquityDollarToken.sol
+++ b/packages/contracts/src/dollar/core/UbiquityDollarToken.sol
@@ -38,7 +38,7 @@ contract UbiquityDollarToken is ERC20Ubiquity {
     /// @notice Modifier checks that the method is called by a user with the "Dollar minter" role
     modifier onlyDollarMinter() {
         require(
-            accessCtrl.hasRole(DOLLAR_TOKEN_MINTER_ROLE, msg.sender),
+            accessControl.hasRole(DOLLAR_TOKEN_MINTER_ROLE, msg.sender),
             "Dollar token: not minter"
         );
         _;
@@ -47,7 +47,7 @@ contract UbiquityDollarToken is ERC20Ubiquity {
     /// @notice Modifier checks that the method is called by a user with the "Dollar burner" role
     modifier onlyDollarBurner() {
         require(
-            accessCtrl.hasRole(DOLLAR_TOKEN_BURNER_ROLE, msg.sender),
+            accessControl.hasRole(DOLLAR_TOKEN_BURNER_ROLE, msg.sender),
             "Dollar token: not burner"
         );
         _;
@@ -65,7 +65,7 @@ contract UbiquityDollarToken is ERC20Ubiquity {
      */
     function setIncentiveContract(address account, address incentive) external {
         require(
-            accessCtrl.hasRole(GOVERNANCE_TOKEN_MANAGER_ROLE, msg.sender),
+            accessControl.hasRole(GOVERNANCE_TOKEN_MANAGER_ROLE, msg.sender),
             "Dollar: must have admin role"
         );
 

--- a/packages/contracts/src/dollar/core/UbiquityGovernanceToken.sol
+++ b/packages/contracts/src/dollar/core/UbiquityGovernanceToken.sol
@@ -25,7 +25,7 @@ contract UbiquityGovernanceToken is ERC20Ubiquity {
     /// @notice Modifier checks that the method is called by a user with the "Governance minter" role
     modifier onlyGovernanceMinter() {
         require(
-            accessCtrl.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, msg.sender),
+            accessControl.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, msg.sender),
             "Governance token: not minter"
         );
         _;
@@ -34,7 +34,7 @@ contract UbiquityGovernanceToken is ERC20Ubiquity {
     /// @notice Modifier checks that the method is called by a user with the "Governance burner" role
     modifier onlyGovernanceBurner() {
         require(
-            accessCtrl.hasRole(GOVERNANCE_TOKEN_BURNER_ROLE, msg.sender),
+            accessControl.hasRole(GOVERNANCE_TOKEN_BURNER_ROLE, msg.sender),
             "Governance token: not burner"
         );
         _;

--- a/packages/contracts/src/dollar/facets/CreditNftManagerFacet.sol
+++ b/packages/contracts/src/dollar/facets/CreditNftManagerFacet.sol
@@ -21,29 +21,29 @@ contract CreditNftManagerFacet is Modifiers {
      * Governance tokens using `rate` conversion rate
      * @param rate Credit NFT to Governance tokens conversion rate
      */
-    function setExpiredCreditNFTConversionRate(
+    function setExpiredCreditNftConversionRate(
         uint256 rate
-    ) external onlyCreditNFTManager {
-        LibCreditNftManager.setExpiredCreditNFTConversionRate(rate);
+    ) external onlyCreditNftManager {
+        LibCreditNftManager.setExpiredCreditNftConversionRate(rate);
     }
 
     /**
      * @notice Returns Credit NFT to Governance conversion rate
      * @return Conversion rate
      */
-    function expiredCreditNFTConversionRate() external view returns (uint256) {
-        return LibCreditNftManager.expiredCreditNFTConversionRate();
+    function expiredCreditNftConversionRate() external view returns (uint256) {
+        return LibCreditNftManager.expiredCreditNftConversionRate();
     }
 
     /**
      * @notice Sets Credit NFT block lifespan
-     * @param _creditNFTLengthBlocks The number of blocks during which Credit NFTs can be
+     * @param _creditNftLengthBlocks The number of blocks during which Credit NFTs can be
      * redeemed for Dollars
      */
-    function setCreditNFTLength(
-        uint256 _creditNFTLengthBlocks
-    ) external onlyCreditNFTManager {
-        LibCreditNftManager.setCreditNFTLength(_creditNFTLengthBlocks);
+    function setCreditNftLength(
+        uint256 _creditNftLengthBlocks
+    ) external onlyCreditNftManager {
+        LibCreditNftManager.setCreditNftLength(_creditNftLengthBlocks);
     }
 
     /**
@@ -51,8 +51,8 @@ contract CreditNftManagerFacet is Modifiers {
      * @return Number of blocks during which Credit NFTs can be
      * redeemed for Dollars
      */
-    function creditNFTLengthBlocks() external view returns (uint256) {
-        return LibCreditNftManager.creditNFTLengthBlocks();
+    function creditNftLengthBlocks() external view returns (uint256) {
+        return LibCreditNftManager.creditNftLengthBlocks();
     }
 
     /**
@@ -84,10 +84,10 @@ contract CreditNftManagerFacet is Modifiers {
      * @param amount Amount of Dollars to burn
      * @return Amount of Credit NFTs to be minted
      */
-    function getCreditNFTReturnedForDollars(
+    function getCreditNftReturnedForDollars(
         uint256 amount
     ) external view returns (uint256) {
-        return LibCreditNftManager.getCreditNFTReturnedForDollars(amount);
+        return LibCreditNftManager.getCreditNftReturnedForDollars(amount);
     }
 
     /**
@@ -156,17 +156,17 @@ contract CreditNftManagerFacet is Modifiers {
     }
 
     /**
-     * @notice Burns expired Credit NFTs for Governance tokens at `expiredCreditNFTConversionRate` rate
+     * @notice Burns expired Credit NFTs for Governance tokens at `expiredCreditNftConversionRate` rate
      * @param id Credit NFT timestamp
      * @param amount Amount of Credit NFTs to burn
      * @return governanceAmount Amount of Governance tokens minted to Credit NFT holder
      */
-    function burnExpiredCreditNFTForGovernance(
+    function burnExpiredCreditNftForGovernance(
         uint256 id,
         uint256 amount
     ) public returns (uint256 governanceAmount) {
         return
-            LibCreditNftManager.burnExpiredCreditNFTForGovernance(id, amount);
+            LibCreditNftManager.burnExpiredCreditNftForGovernance(id, amount);
     }
 
     /**
@@ -176,11 +176,11 @@ contract CreditNftManagerFacet is Modifiers {
      * @param amount Amount of Credit NFTs to burn
      * @return Credit tokens balance of `msg.sender`
      */
-    function burnCreditNFTForCredit(
+    function burnCreditNftForCredit(
         uint256 id,
         uint256 amount
     ) public returns (uint256) {
-        return LibCreditNftManager.burnCreditNFTForCredit(id, amount);
+        return LibCreditNftManager.burnCreditNftForCredit(id, amount);
     }
 
     /**
@@ -204,7 +204,7 @@ contract CreditNftManagerFacet is Modifiers {
         uint256 id,
         uint256 amount
     ) public returns (uint256) {
-        return LibCreditNftManager.redeemCreditNFT(id, amount);
+        return LibCreditNftManager.redeemCreditNft(id, amount);
     }
 
     /**

--- a/packages/contracts/src/dollar/facets/CreditNftRedemptionCalculatorFacet.sol
+++ b/packages/contracts/src/dollar/facets/CreditNftRedemptionCalculatorFacet.sol
@@ -12,6 +12,6 @@ contract CreditNftRedemptionCalculatorFacet is ICreditNftRedemptionCalculator {
         uint256 dollarsToBurn
     ) external view override returns (uint256) {
         return
-            LibCreditNftRedemptionCalculator.getCreditNFTAmount(dollarsToBurn);
+            LibCreditNftRedemptionCalculator.getCreditNftAmount(dollarsToBurn);
     }
 }

--- a/packages/contracts/src/dollar/facets/ManagerFacet.sol
+++ b/packages/contracts/src/dollar/facets/ManagerFacet.sol
@@ -328,7 +328,7 @@ contract ManagerFacet is Modifiers {
      * @notice Returns Credit NFT redemption calculator address
      * @return Credit NFT redemption calculator address
      */
-    function creditNFTCalculatorAddress() external view returns (address) {
+    function creditNftCalculatorAddress() external view returns (address) {
         return address(this);
     }
 

--- a/packages/contracts/src/dollar/interfaces/ICreditNft.sol
+++ b/packages/contracts/src/dollar/interfaces/ICreditNft.sol
@@ -14,9 +14,9 @@ interface ICreditNft is IERC1155 {
 
     /**
      * @notice Burns an `amount` of CreditNfts expiring at `expiryBlockNumber` from `creditNftOwner` balance
-     * @param creditNftOwner Owner of those CreditNFTs
+     * @param creditNftOwner Owner of those CreditNfts
      * @param amount Amount of tokens to burn
-     * @param expiryBlockNumber Expiration block number of the CreditNFTs to burn
+     * @param expiryBlockNumber Expiration block number of the CreditNfts to burn
      */
     function burnCreditNft(
         address creditNftOwner,
@@ -28,7 +28,7 @@ interface ICreditNft is IERC1155 {
      * @notice Mint an `amount` of CreditNfts expiring at `expiryBlockNumber` for a certain `recipient`
      * @param recipient Address where to mint tokens
      * @param amount Amount of tokens to mint
-     * @param expiryBlockNumber Expiration block number of the CreditNFTs to mint
+     * @param expiryBlockNumber Expiration block number of the CreditNfts to mint
      */
     function mintCreditNft(
         address recipient,

--- a/packages/contracts/src/dollar/libraries/LibAppStorage.sol
+++ b/packages/contracts/src/dollar/libraries/LibAppStorage.sol
@@ -12,7 +12,7 @@ struct AppStorage {
     // others
     address dollarTokenAddress;
     address creditNftAddress;
-    address creditNFTCalculatorAddress;
+    address creditNftCalculatorAddress;
     address dollarMintCalculatorAddress;
     address stakingShareAddress;
     address stakingContractAddress;
@@ -85,7 +85,7 @@ contract Modifiers {
     }
 
     /// @notice Checks that method is called by address with the `CREDIT_NFT_MANAGER_ROLE` role
-    modifier onlyCreditNFTManager() {
+    modifier onlyCreditNftManager() {
         require(
             LibAccessControl.hasRole(CREDIT_NFT_MANAGER_ROLE, msg.sender),
             "Caller is not a Credit NFT manager"

--- a/packages/contracts/src/dollar/libraries/LibCreditNftManager.sol
+++ b/packages/contracts/src/dollar/libraries/LibCreditNftManager.sol
@@ -46,7 +46,7 @@ library LibCreditNftManager {
     );
 
     /// @notice Struct used as a storage for the current library
-    struct CreditNftMgrData {
+    struct CreditNftManagerData {
         //the amount of dollars we minted this cycle, so we can calculate delta.
         // should be reset to 0 when cycle ends
         uint256 dollarsMintedThisCycle;
@@ -63,7 +63,7 @@ library LibCreditNftManager {
     function creditNftStorage()
         internal
         pure
-        returns (CreditNftMgrData storage l)
+        returns (CreditNftManagerData storage l)
     {
         bytes32 slot = CREDIT_NFT_MANAGER_STORAGE_SLOT;
         assembly {
@@ -135,7 +135,7 @@ library LibCreditNftManager {
             LibAppStorage.appStorage().creditNftAddress
         );
         creditNft.updateTotalDebt();
-        CreditNftMgrData storage cs = creditNftStorage();
+        CreditNftManagerData storage cs = creditNftStorage();
         //we are in a down cycle so reset the cycle counter
         // and set the blockHeight Debt
         if (!cs.debtCycle) {
@@ -179,7 +179,7 @@ library LibCreditNftManager {
         //we are in a down cycle so reset the cycle counter
         // and set the blockHeight Debt
         if (!creditNftStorage().debtCycle) {
-            CreditNftMgrData storage cs = creditNftStorage();
+            CreditNftManagerData storage cs = creditNftStorage();
             cs.debtCycle = true;
             cs.blockHeightDebt = block.number;
             cs.dollarsMintedThisCycle = 0;

--- a/packages/contracts/src/dollar/libraries/LibCreditNftManager.sol
+++ b/packages/contracts/src/dollar/libraries/LibCreditNftManager.sol
@@ -34,25 +34,25 @@ library LibCreditNftManager {
         );
 
     /// @notice Emitted when Credit NFT to Governance conversion rate was updated
-    event ExpiredCreditNFTConversionRateChanged(
+    event ExpiredCreditNftConversionRateChanged(
         uint256 newRate,
         uint256 previousRate
     );
 
     /// @notice Emitted when Credit NFT block expiration length was updated
-    event CreditNFTLengthChanged(
-        uint256 newCreditNFTLengthBlocks,
-        uint256 previousCreditNFTLengthBlocks
+    event CreditNftLengthChanged(
+        uint256 newCreditNftLengthBlocks,
+        uint256 previousCreditNftLengthBlocks
     );
 
     /// @notice Struct used as a storage for the current library
-    struct CreditNFTMgrData {
+    struct CreditNftMgrData {
         //the amount of dollars we minted this cycle, so we can calculate delta.
         // should be reset to 0 when cycle ends
         uint256 dollarsMintedThisCycle;
         uint256 blockHeightDebt;
-        uint256 creditNFTLengthBlocks;
-        uint256 expiredCreditNFTConversionRate;
+        uint256 creditNftLengthBlocks;
+        uint256 expiredCreditNftConversionRate;
         bool debtCycle;
     }
 
@@ -60,10 +60,10 @@ library LibCreditNftManager {
      * @notice Returns struct used as a storage for this library
      * @return l Struct used as a storage
      */
-    function creditNFTStorage()
+    function creditNftStorage()
         internal
         pure
-        returns (CreditNFTMgrData storage l)
+        returns (CreditNftMgrData storage l)
     {
         bytes32 slot = CREDIT_NFT_MANAGER_STORAGE_SLOT;
         assembly {
@@ -75,8 +75,8 @@ library LibCreditNftManager {
      * @notice Returns Credit NFT to Governance conversion rate
      * @return Conversion rate
      */
-    function expiredCreditNFTConversionRate() internal view returns (uint256) {
-        return creditNFTStorage().expiredCreditNFTConversionRate;
+    function expiredCreditNftConversionRate() internal view returns (uint256) {
+        return creditNftStorage().expiredCreditNftConversionRate;
     }
 
     /**
@@ -85,25 +85,25 @@ library LibCreditNftManager {
      * Governance tokens using `rate` conversion rate
      * @param rate Credit NFT to Governance tokens conversion rate
      */
-    function setExpiredCreditNFTConversionRate(uint256 rate) internal {
-        emit ExpiredCreditNFTConversionRateChanged(
+    function setExpiredCreditNftConversionRate(uint256 rate) internal {
+        emit ExpiredCreditNftConversionRateChanged(
             rate,
-            creditNFTStorage().expiredCreditNFTConversionRate
+            creditNftStorage().expiredCreditNftConversionRate
         );
-        creditNFTStorage().expiredCreditNFTConversionRate = rate;
+        creditNftStorage().expiredCreditNftConversionRate = rate;
     }
 
     /**
      * @notice Sets Credit NFT block lifespan
-     * @param _creditNFTLengthBlocks The number of blocks during which Credit NFTs can be
+     * @param _creditNftLengthBlocks The number of blocks during which Credit NFTs can be
      * redeemed for Dollars
      */
-    function setCreditNFTLength(uint256 _creditNFTLengthBlocks) internal {
-        emit CreditNFTLengthChanged(
-            _creditNFTLengthBlocks,
-            creditNFTStorage().creditNFTLengthBlocks
+    function setCreditNftLength(uint256 _creditNftLengthBlocks) internal {
+        emit CreditNftLengthChanged(
+            _creditNftLengthBlocks,
+            creditNftStorage().creditNftLengthBlocks
         );
-        creditNFTStorage().creditNFTLengthBlocks = _creditNFTLengthBlocks;
+        creditNftStorage().creditNftLengthBlocks = _creditNftLengthBlocks;
     }
 
     /**
@@ -111,8 +111,8 @@ library LibCreditNftManager {
      * @return Number of blocks during which Credit NFTs can be
      * redeemed for Dollars
      */
-    function creditNFTLengthBlocks() internal view returns (uint256) {
-        return creditNFTStorage().creditNFTLengthBlocks;
+    function creditNftLengthBlocks() internal view returns (uint256) {
+        return creditNftStorage().creditNftLengthBlocks;
     }
 
     /**
@@ -131,11 +131,11 @@ library LibCreditNftManager {
             "Price must be below 1 to mint Credit NFT"
         );
 
-        CreditNft creditNFT = CreditNft(
+        CreditNft creditNft = CreditNft(
             LibAppStorage.appStorage().creditNftAddress
         );
-        creditNFT.updateTotalDebt();
-        CreditNFTMgrData storage cs = creditNFTStorage();
+        creditNft.updateTotalDebt();
+        CreditNftMgrData storage cs = creditNftStorage();
         //we are in a down cycle so reset the cycle counter
         // and set the blockHeight Debt
         if (!cs.debtCycle) {
@@ -144,8 +144,8 @@ library LibCreditNftManager {
             cs.dollarsMintedThisCycle = 0;
         }
 
-        uint256 creditNFTToMint = LibCreditNftRedemptionCalculator
-            .getCreditNFTAmount(amount);
+        uint256 creditNftToMint = LibCreditNftRedemptionCalculator
+            .getCreditNftAmount(amount);
 
         // we burn user's dollars.
         IERC20Ubiquity(LibAppStorage.appStorage().dollarTokenAddress).burnFrom(
@@ -153,8 +153,8 @@ library LibCreditNftManager {
             amount
         );
 
-        uint256 expiryBlockNumber = block.number + (cs.creditNFTLengthBlocks);
-        creditNFT.mintCreditNft(msg.sender, creditNFTToMint, expiryBlockNumber);
+        uint256 expiryBlockNumber = block.number + (cs.creditNftLengthBlocks);
+        creditNft.mintCreditNft(msg.sender, creditNftToMint, expiryBlockNumber);
 
         //give the caller the block number of the minted nft
         return expiryBlockNumber;
@@ -173,13 +173,13 @@ library LibCreditNftManager {
 
         require(twapPrice < 1 ether, "Price must be below 1 to mint Credit");
         AppStorage storage store = LibAppStorage.appStorage();
-        CreditNft creditNFT = CreditNft(store.creditNftAddress);
-        creditNFT.updateTotalDebt();
+        CreditNft creditNft = CreditNft(store.creditNftAddress);
+        creditNft.updateTotalDebt();
 
         //we are in a down cycle so reset the cycle counter
         // and set the blockHeight Debt
-        if (!creditNFTStorage().debtCycle) {
-            CreditNFTMgrData storage cs = creditNFTStorage();
+        if (!creditNftStorage().debtCycle) {
+            CreditNftMgrData storage cs = creditNftStorage();
             cs.debtCycle = true;
             cs.blockHeightDebt = block.number;
             cs.dollarsMintedThisCycle = 0;
@@ -187,7 +187,7 @@ library LibCreditNftManager {
 
         uint256 creditToMint = LibCreditRedemptionCalculator.getCreditAmount(
             amount,
-            creditNFTStorage().blockHeightDebt
+            creditNftStorage().blockHeightDebt
         );
 
         // we burn user's dollars.
@@ -207,10 +207,10 @@ library LibCreditNftManager {
      * @param amount Amount of Dollars to burn
      * @return Amount of Credit NFTs to be minted
      */
-    function getCreditNFTReturnedForDollars(
+    function getCreditNftReturnedForDollars(
         uint256 amount
     ) internal view returns (uint256) {
-        return LibCreditNftRedemptionCalculator.getCreditNFTAmount(amount);
+        return LibCreditNftRedemptionCalculator.getCreditNftAmount(amount);
     }
 
     /**
@@ -224,7 +224,7 @@ library LibCreditNftManager {
         return
             LibCreditRedemptionCalculator.getCreditAmount(
                 amount,
-                creditNFTStorage().blockHeightDebt
+                creditNftStorage().blockHeightDebt
             );
     }
 
@@ -261,27 +261,27 @@ library LibCreditNftManager {
     }
 
     /**
-     * @notice Burns expired Credit NFTs for Governance tokens at `expiredCreditNFTConversionRate` rate
+     * @notice Burns expired Credit NFTs for Governance tokens at `expiredCreditNftConversionRate` rate
      * @param id Credit NFT timestamp
      * @param amount Amount of Credit NFTs to burn
      * @return governanceAmount Amount of Governance tokens minted to Credit NFT holder
      */
-    function burnExpiredCreditNFTForGovernance(
+    function burnExpiredCreditNftForGovernance(
         uint256 id,
         uint256 amount
     ) public returns (uint256 governanceAmount) {
         // Check whether Credit NFT hasn't expired --> Burn Credit NFT.
-        CreditNft creditNFT = CreditNft(
+        CreditNft creditNft = CreditNft(
             LibAppStorage.appStorage().creditNftAddress
         );
 
         require(id <= block.number, "Credit NFT has not expired");
         require(
-            creditNFT.balanceOf(msg.sender, id) >= amount,
+            creditNft.balanceOf(msg.sender, id) >= amount,
             "User not enough Credit NFT"
         );
 
-        creditNFT.burnCreditNft(msg.sender, amount, id);
+        creditNft.burnCreditNft(msg.sender, amount, id);
 
         // Mint Governance Token to this contract. Transfer Governance Token to msg.sender i.e. Credit NFT holder
         IERC20Ubiquity governanceToken = IERC20Ubiquity(
@@ -289,7 +289,7 @@ library LibCreditNftManager {
         );
         governanceAmount =
             amount /
-            creditNFTStorage().expiredCreditNFTConversionRate;
+            creditNftStorage().expiredCreditNftConversionRate;
         governanceToken.mint(msg.sender, governanceAmount);
     }
 
@@ -300,22 +300,22 @@ library LibCreditNftManager {
      * @param amount Amount of Credit NFTs to burn
      * @return Credit tokens balance of `msg.sender`
      */
-    function burnCreditNFTForCredit(
+    function burnCreditNftForCredit(
         uint256 id,
         uint256 amount
     ) public returns (uint256) {
         // Check whether Credit NFT hasn't expired --> Burn Credit NFT.
-        CreditNft creditNFT = CreditNft(
+        CreditNft creditNft = CreditNft(
             LibAppStorage.appStorage().creditNftAddress
         );
 
         require(id > block.timestamp, "Credit NFT has expired");
         require(
-            creditNFT.balanceOf(msg.sender, id) >= amount,
+            creditNft.balanceOf(msg.sender, id) >= amount,
             "User not enough Credit NFT"
         );
 
-        creditNFT.burnCreditNft(msg.sender, amount, id);
+        creditNft.burnCreditNft(msg.sender, amount, id);
 
         // Mint LP tokens to this contract. Transfer LP tokens to msg.sender i.e. Credit NFT holder
         UbiquityCreditToken creditToken = UbiquityCreditToken(
@@ -337,8 +337,8 @@ library LibCreditNftManager {
     ) public returns (uint256) {
         uint256 twapPrice = LibTWAPOracle.getTwapPrice();
         require(twapPrice > 1 ether, "Price must be above 1");
-        if (creditNFTStorage().debtCycle) {
-            creditNFTStorage().debtCycle = false;
+        if (creditNftStorage().debtCycle) {
+            creditNftStorage().debtCycle = false;
         }
         UbiquityCreditToken creditToken = UbiquityCreditToken(
             LibAppStorage.appStorage().creditTokenAddress
@@ -373,7 +373,7 @@ library LibCreditNftManager {
      * @param amount Amount of Credit NFTs to burn
      * @return Amount of unredeemed Credit NFTs
      */
-    function redeemCreditNFT(
+    function redeemCreditNft(
         uint256 id,
         uint256 amount
     ) public returns (uint256) {
@@ -383,15 +383,15 @@ library LibCreditNftManager {
             twapPrice > 1 ether,
             "Price must be above 1 to redeem Credit NFT"
         );
-        if (creditNFTStorage().debtCycle) {
-            creditNFTStorage().debtCycle = false;
+        if (creditNftStorage().debtCycle) {
+            creditNftStorage().debtCycle = false;
         }
         AppStorage storage store = LibAppStorage.appStorage();
-        CreditNft creditNFT = CreditNft(store.creditNftAddress);
+        CreditNft creditNft = CreditNft(store.creditNftAddress);
 
         require(id > block.number, "Credit NFT has expired");
         require(
-            creditNFT.balanceOf(msg.sender, id) >= amount,
+            creditNft.balanceOf(msg.sender, id) >= amount,
             "User not enough Credit NFT"
         );
 
@@ -406,24 +406,24 @@ library LibCreditNftManager {
             creditToken.totalSupply() <= dollar.balanceOf(address(this)),
             "There aren't enough Dollar to redeem currently"
         );
-        uint256 maxRedeemableCreditNFT = dollar.balanceOf(address(this)) -
+        uint256 maxRedeemableCreditNft = dollar.balanceOf(address(this)) -
             creditToken.totalSupply();
-        uint256 creditNFTToRedeem = amount;
+        uint256 creditNftToRedeem = amount;
 
-        if (amount > maxRedeemableCreditNFT) {
-            creditNFTToRedeem = maxRedeemableCreditNFT;
+        if (amount > maxRedeemableCreditNft) {
+            creditNftToRedeem = maxRedeemableCreditNft;
         }
         require(
             dollar.balanceOf(address(this)) > 0,
             "There aren't any Dollar to redeem currently"
         );
 
-        // creditNFTManager must be an operator to transfer on behalf of msg.sender
-        creditNFT.burnCreditNft(msg.sender, creditNFTToRedeem, id);
+        // creditNftManager must be an operator to transfer on behalf of msg.sender
+        creditNft.burnCreditNft(msg.sender, creditNftToRedeem, id);
 
-        dollar.transfer(msg.sender, creditNFTToRedeem);
+        dollar.transfer(msg.sender, creditNftToRedeem);
 
-        return amount - (creditNFTToRedeem);
+        return amount - (creditNftToRedeem);
     }
 
     /**
@@ -436,15 +436,15 @@ library LibCreditNftManager {
     function mintClaimableDollars() public {
         AppStorage storage store = LibAppStorage.appStorage();
 
-        CreditNft creditNFT = CreditNft(store.creditNftAddress);
-        creditNFT.updateTotalDebt();
+        CreditNft creditNft = CreditNft(store.creditNftAddress);
+        creditNft.updateTotalDebt();
 
         uint256 totalMintableDollars = IDollarMintCalculator(address(this))
             .getDollarsToMint();
         uint256 dollarsToMint = totalMintableDollars -
-            (creditNFTStorage().dollarsMintedThisCycle);
+            (creditNftStorage().dollarsMintedThisCycle);
         //update the dollars for this cycle
-        creditNFTStorage().dollarsMintedThisCycle = totalMintableDollars;
+        creditNftStorage().dollarsMintedThisCycle = totalMintableDollars;
 
         // Dollar should be minted to address(this)
         IERC20Ubiquity dollar = IERC20Ubiquity(store.dollarTokenAddress);
@@ -454,7 +454,7 @@ library LibCreditNftManager {
         );
 
         uint256 currentRedeemableBalance = dollar.balanceOf(address(this));
-        uint256 totalOutstandingDebt = creditNFT.getTotalOutstandingDebt() +
+        uint256 totalOutstandingDebt = creditNft.getTotalOutstandingDebt() +
             creditToken.totalSupply();
 
         if (currentRedeemableBalance > totalOutstandingDebt) {

--- a/packages/contracts/src/dollar/libraries/LibCreditNftRedemptionCalculator.sol
+++ b/packages/contracts/src/dollar/libraries/LibCreditNftRedemptionCalculator.sol
@@ -17,16 +17,16 @@ library LibCreditNftRedemptionCalculator {
      * @param dollarsToBurn Amount of Dollars to burn
      * @return Amount of Credit NFTs to mint
      */
-    function getCreditNFTAmount(
+    function getCreditNftAmount(
         uint256 dollarsToBurn
     ) internal view returns (uint256) {
         AppStorage storage store = LibAppStorage.appStorage();
-        address creditNFTAddress = store.creditNftAddress;
-        CreditNft cNFT = CreditNft(creditNFTAddress);
+        address creditNftAddress = store.creditNftAddress;
+        CreditNft cNFT = CreditNft(creditNftAddress);
         require(
             cNFT.getTotalOutstandingDebt() <
                 IERC20(store.dollarTokenAddress).totalSupply(),
-            "CreditNFT to Dollar: DEBT_TOO_HIGH"
+            "CreditNft to Dollar: DEBT_TOO_HIGH"
         );
         bytes16 one = uint256(1).fromUInt();
         bytes16 totalDebt = cNFT.getTotalOutstandingDebt().fromUInt();

--- a/packages/contracts/src/dollar/libraries/LibCreditRedemptionCalculator.sol
+++ b/packages/contracts/src/dollar/libraries/LibCreditRedemptionCalculator.sol
@@ -69,8 +69,8 @@ library LibCreditRedemptionCalculator {
         uint256 blockHeightDebt
     ) internal view returns (uint256) {
         AppStorage storage store = LibAppStorage.appStorage();
-        address creditNFTAddress = store.creditNftAddress;
-        CreditNft cNFT = CreditNft(creditNFTAddress);
+        address creditNftAddress = store.creditNftAddress;
+        CreditNft cNFT = CreditNft(creditNftAddress);
         require(
             cNFT.getTotalOutstandingDebt() <
                 IERC20(store.dollarTokenAddress).totalSupply(),

--- a/packages/contracts/src/dollar/upgradeInitializers/DiamondInit.sol
+++ b/packages/contracts/src/dollar/upgradeInitializers/DiamondInit.sol
@@ -35,7 +35,7 @@ contract DiamondInit is Modifiers {
         uint256[] amounts;
         uint256[] stakingShareIDs;
         uint256 governancePerBlock;
-        uint256 creditNFTLengthBlocks;
+        uint256 creditNftLengthBlocks;
     }
 
     /**
@@ -83,14 +83,14 @@ contract DiamondInit is Modifiers {
             _args.stakingShareIDs,
             _args.governancePerBlock
         );
-        // creditNFTManager
-        /// @param _creditNFTLengthBlocks how many blocks Credit NFT last. can't be changed
+        // creditNftManager
+        /// @param _creditNftLengthBlocks how many blocks Credit NFT last. can't be changed
         /// once set (unless migrated)
-        LibCreditNftManager.creditNFTStorage().creditNFTLengthBlocks = _args
-            .creditNFTLengthBlocks;
+        LibCreditNftManager.creditNftStorage().creditNftLengthBlocks = _args
+            .creditNftLengthBlocks;
         LibCreditNftManager
-            .creditNFTStorage()
-            .expiredCreditNFTConversionRate = 2;
+            .creditNftStorage()
+            .expiredCreditNftConversionRate = 2;
 
         LibCreditRedemptionCalculator
             .creditRedemptionCalculatorStorage()

--- a/packages/contracts/test/diamond/DiamondInit.t.sol
+++ b/packages/contracts/test/diamond/DiamondInit.t.sol
@@ -27,7 +27,7 @@ contract DiamondInitTest is Test {
             amounts: new uint256[](0),
             stakingShareIDs: new uint256[](0),
             governancePerBlock: 10e18,
-            creditNFTLengthBlocks: 100
+            creditNftLengthBlocks: 100
         });
         dInit.init(initArgs);
 

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -78,9 +78,9 @@ abstract contract DiamondSetup is DiamondTestHelper {
 
     BondingCurveFacet IBondingCurveFacet;
 
-    CreditNftManagerFacet ICreditNftMgrFacet;
-    CreditNftRedemptionCalculatorFacet ICreditNftRedCalcFacet;
-    CreditRedemptionCalculatorFacet ICreditRedCalcFacet;
+    CreditNftManagerFacet ICreditNftManagerFacet;
+    CreditNftRedemptionCalculatorFacet ICreditNftRedemptionCalculationFacet;
+    CreditRedemptionCalculatorFacet ICreditRedemptionCalculationFacet;
 
     DollarMintCalculatorFacet IDollarMintCalcFacet;
     DollarMintExcessFacet IDollarMintExcessFacet;
@@ -96,7 +96,7 @@ abstract contract DiamondSetup is DiamondTestHelper {
 
     address owner;
     address admin;
-    address tokenMgr;
+    address tokenManager;
     address user1;
     address contract1;
     address contract2;
@@ -127,7 +127,7 @@ abstract contract DiamondSetup is DiamondTestHelper {
         incentive_addr = address(new MockIncentive());
         owner = generateAddress("Owner", false, 10 ether);
         admin = generateAddress("Admin", false, 10 ether);
-        tokenMgr = generateAddress("TokenMgr", false, 10 ether);
+        tokenManager = generateAddress("TokenManager", false, 10 ether);
 
         user1 = generateAddress("User1", false, 10 ether);
         contract1 = generateAddress("Contract1", true, 10 ether);
@@ -689,11 +689,11 @@ abstract contract DiamondSetup is DiamondTestHelper {
         );
         IOwnershipFacet = OwnershipFacet(address(diamond));
 
-        ICreditNftMgrFacet = CreditNftManagerFacet(address(diamond));
-        ICreditNftRedCalcFacet = CreditNftRedemptionCalculatorFacet(
+        ICreditNftManagerFacet = CreditNftManagerFacet(address(diamond));
+        ICreditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(
             address(diamond)
         );
-        ICreditRedCalcFacet = CreditRedemptionCalculatorFacet(address(diamond));
+        ICreditRedemptionCalculationFacet = CreditRedemptionCalculatorFacet(address(diamond));
 
         IDollarMintCalcFacet = DollarMintCalculatorFacet(address(diamond));
         IDollarMintExcessFacet = DollarMintExcessFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -52,8 +52,8 @@ abstract contract DiamondSetup is DiamondTestHelper {
     BondingCurveFacet bondingCurveFacet;
     CurveDollarIncentiveFacet curveDollarIncentiveFacet;
 
-    CreditNftManagerFacet creditNFTManagerFacet;
-    CreditNftRedemptionCalculatorFacet creditNFTRedemptionCalculatorFacet;
+    CreditNftManagerFacet creditNftManagerFacet;
+    CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculatorFacet;
     CreditRedemptionCalculatorFacet creditRedemptionCalculatorFacet;
 
     DollarMintCalculatorFacet dollarMintCalculatorFacet;
@@ -66,7 +66,7 @@ abstract contract DiamondSetup is DiamondTestHelper {
     IDiamondCut ICut;
     ManagerFacet IManager;
     TWAPOracleDollar3poolFacet ITWAPOracleDollar3pool;
-    AccessControlFacet IAccessCtrl;
+    AccessControlFacet IAccessControl;
 
     CollectableDustFacet ICollectableDustFacet;
     ChefFacet IChefFacet;
@@ -78,8 +78,8 @@ abstract contract DiamondSetup is DiamondTestHelper {
 
     BondingCurveFacet IBondingCurveFacet;
 
-    CreditNftManagerFacet ICreditNFTMgrFacet;
-    CreditNftRedemptionCalculatorFacet ICreditNFTRedCalcFacet;
+    CreditNftManagerFacet ICreditNftMgrFacet;
+    CreditNftRedemptionCalculatorFacet ICreditNftRedCalcFacet;
     CreditRedemptionCalculatorFacet ICreditRedCalcFacet;
 
     DollarMintCalculatorFacet IDollarMintCalcFacet;
@@ -115,8 +115,8 @@ abstract contract DiamondSetup is DiamondTestHelper {
     bytes4[] selectorsOfBondingCurveFacet;
     bytes4[] selectorsOfCurveDollarIncentiveFacet;
 
-    bytes4[] selectorsOfCreditNFTManagerFacet;
-    bytes4[] selectorsOfCreditNFTRedemptionCalculatorFacet;
+    bytes4[] selectorsOfCreditNftManagerFacet;
+    bytes4[] selectorsOfCreditNftRedemptionCalculatorFacet;
     bytes4[] selectorsOfCreditRedemptionCalculatorFacet;
 
     bytes4[] selectorsOfDollarMintCalculatorFacet;
@@ -218,7 +218,7 @@ abstract contract DiamondSetup is DiamondTestHelper {
             managerFacet.creditCalculatorAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.creditNFTCalculatorAddress.selector
+            managerFacet.creditNftCalculatorAddress.selector
         );
         selectorsOfManagerFacet.push(
             managerFacet.dollarMintCalculatorAddress.selector
@@ -402,55 +402,55 @@ abstract contract DiamondSetup is DiamondTestHelper {
         );
 
         // Credit facets
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.creditNFTLengthBlocks.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.creditNftLengthBlocks.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.expiredCreditNFTConversionRate.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.expiredCreditNftConversionRate.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.setExpiredCreditNFTConversionRate.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.setExpiredCreditNftConversionRate.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.setCreditNFTLength.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.setCreditNftLength.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.exchangeDollarsForCreditNft.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.exchangeDollarsForCreditNft.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.exchangeDollarsForCredit.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.exchangeDollarsForCredit.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.getCreditNFTReturnedForDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.getCreditNftReturnedForDollars.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.getCreditReturnedForDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.getCreditReturnedForDollars.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.onERC1155Received.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.onERC1155Received.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.onERC1155BatchReceived.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.onERC1155BatchReceived.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.burnExpiredCreditNFTForGovernance.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.burnExpiredCreditNftForGovernance.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.burnCreditNFTForCredit.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.burnCreditNftForCredit.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.burnCreditTokensForDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.burnCreditTokensForDollars.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.redeemCreditNft.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.redeemCreditNft.selector
         );
-        selectorsOfCreditNFTManagerFacet.push(
-            creditNFTManagerFacet.mintClaimableDollars.selector
+        selectorsOfCreditNftManagerFacet.push(
+            creditNftManagerFacet.mintClaimableDollars.selector
         );
 
         // Credit NFT Redemption Calculator
-        selectorsOfCreditNFTRedemptionCalculatorFacet.push(
-            creditNFTRedemptionCalculatorFacet.getCreditNftAmount.selector
+        selectorsOfCreditNftRedemptionCalculatorFacet.push(
+            creditNftRedemptionCalculatorFacet.getCreditNftAmount.selector
         );
 
         // Credit Redemption Calculator
@@ -488,8 +488,8 @@ abstract contract DiamondSetup is DiamondTestHelper {
         bondingCurveFacet = new BondingCurveFacet();
         curveDollarIncentiveFacet = new CurveDollarIncentiveFacet();
 
-        creditNFTManagerFacet = new CreditNftManagerFacet();
-        creditNFTRedemptionCalculatorFacet = new CreditNftRedemptionCalculatorFacet();
+        creditNftManagerFacet = new CreditNftManagerFacet();
+        creditNftRedemptionCalculatorFacet = new CreditNftRedemptionCalculatorFacet();
         creditRedemptionCalculatorFacet = new CreditRedemptionCalculatorFacet();
 
         dollarMintCalculatorFacet = new DollarMintCalculatorFacet();
@@ -509,8 +509,8 @@ abstract contract DiamondSetup is DiamondTestHelper {
             "UbiquityPoolFacet",
             "StakingFormulasFacet",
             "CurveDollarIncentiveFacet",
-            "CreditNFTManagerFacet",
-            "CreditNFTRedemptionCalculatorFacet",
+            "CreditNftManagerFacet",
+            "CreditNftRedemptionCalculatorFacet",
             "CreditRedemptionCalculatorFacet",
             "DollarMintCalculatorFacet",
             "DollarMintExcessFacet",
@@ -523,7 +523,7 @@ abstract contract DiamondSetup is DiamondTestHelper {
             amounts: new uint256[](0),
             stakingShareIDs: new uint256[](0),
             governancePerBlock: 10e18,
-            creditNFTLengthBlocks: 100
+            creditNftLengthBlocks: 100
         });
         // diamond arguments
         DiamondArgs memory _args = DiamondArgs({
@@ -614,16 +614,16 @@ abstract contract DiamondSetup is DiamondTestHelper {
         );
         cuts[10] = (
             FacetCut({
-                facetAddress: address(creditNFTManagerFacet),
+                facetAddress: address(creditNftManagerFacet),
                 action: FacetCutAction.Add,
-                functionSelectors: selectorsOfCreditNFTManagerFacet
+                functionSelectors: selectorsOfCreditNftManagerFacet
             })
         );
         cuts[11] = (
             FacetCut({
-                facetAddress: address(creditNFTRedemptionCalculatorFacet),
+                facetAddress: address(creditNftRedemptionCalculatorFacet),
                 action: FacetCutAction.Add,
-                functionSelectors: selectorsOfCreditNFTRedemptionCalculatorFacet
+                functionSelectors: selectorsOfCreditNftRedemptionCalculatorFacet
             })
         );
         cuts[12] = (
@@ -675,7 +675,7 @@ abstract contract DiamondSetup is DiamondTestHelper {
         ILoupe = IDiamondLoupe(address(diamond));
         ICut = IDiamondCut(address(diamond));
         IManager = ManagerFacet(address(diamond));
-        IAccessCtrl = AccessControlFacet(address(diamond));
+        IAccessControl = AccessControlFacet(address(diamond));
         ITWAPOracleDollar3pool = TWAPOracleDollar3poolFacet(address(diamond));
 
         ICollectableDustFacet = CollectableDustFacet(address(diamond));
@@ -689,8 +689,8 @@ abstract contract DiamondSetup is DiamondTestHelper {
         );
         IOwnershipFacet = OwnershipFacet(address(diamond));
 
-        ICreditNFTMgrFacet = CreditNftManagerFacet(address(diamond));
-        ICreditNFTRedCalcFacet = CreditNftRedemptionCalculatorFacet(
+        ICreditNftMgrFacet = CreditNftManagerFacet(address(diamond));
+        ICreditNftRedCalcFacet = CreditNftRedemptionCalculatorFacet(
             address(diamond)
         );
         ICreditRedCalcFacet = CreditRedemptionCalculatorFacet(address(diamond));
@@ -702,13 +702,13 @@ abstract contract DiamondSetup is DiamondTestHelper {
         facetAddressList = ILoupe.facetAddresses();
         vm.startPrank(admin);
         // grant diamond dollar minting and burning rights
-        IAccessCtrl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(DOLLAR_TOKEN_BURNER_ROLE, address(diamond));
+        IAccessControl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(DOLLAR_TOKEN_BURNER_ROLE, address(diamond));
         // grant diamond token admin rights
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, address(diamond));
         // grant diamond token minter rights
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(CURVE_DOLLAR_MANAGER_ROLE, address(diamond));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(CURVE_DOLLAR_MANAGER_ROLE, address(diamond));
         // add staking shares
         string
             memory uri = "https://bafybeifibz4fhk4yag5reupmgh5cdbm2oladke4zfd7ldyw7avgipocpmy.ipfs.infura-ipfs.io/";

--- a/packages/contracts/test/diamond/ERC20UbiquityDollarTest.t.sol
+++ b/packages/contracts/test/diamond/ERC20UbiquityDollarTest.t.sol
@@ -169,7 +169,7 @@ contract ERC20UbiquityDollarTest is DiamondSetup {
         // create burner role
         address burner = makeAddr("burner");
         vm.prank(admin);
-        IAccessCtrl.grantRole(keccak256("DOLLAR_TOKEN_BURNER_ROLE"), burner);
+        IAccessControl.grantRole(keccak256("DOLLAR_TOKEN_BURNER_ROLE"), burner);
         // admin pauses contract
         vm.prank(admin);
         IDollar.pause();
@@ -188,7 +188,7 @@ contract ERC20UbiquityDollarTest is DiamondSetup {
         // create burner role
         address burner = makeAddr("burner");
         vm.prank(admin);
-        IAccessCtrl.grantRole(keccak256("DOLLAR_TOKEN_BURNER_ROLE"), burner);
+        IAccessControl.grantRole(keccak256("DOLLAR_TOKEN_BURNER_ROLE"), burner);
         // burn 50 tokens for user
         vm.prank(burner);
         vm.expectEmit(true, true, true, true);
@@ -245,10 +245,10 @@ contract ERC20UbiquityDollarTest is DiamondSetup {
 
     function testUnpause_ShouldUnpauseContract() public {
         vm.startPrank(admin);
-        IAccessCtrl.pause();
-        assertTrue(IAccessCtrl.paused());
-        IAccessCtrl.unpause();
-        assertFalse(IAccessCtrl.paused());
+        IAccessControl.pause();
+        assertTrue(IAccessControl.paused());
+        IAccessControl.unpause();
+        assertFalse(IAccessControl.paused());
         vm.stopPrank();
     }
 

--- a/packages/contracts/test/diamond/facets/AccessControlFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/AccessControlFacet.t.sol
@@ -33,7 +33,7 @@ contract AccessControlFacetTest is DiamondSetup {
         vm.prank(admin);
         vm.expectEmit(true, true, true, true);
         emit RoleGranted(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
     }
 
     // test grantRole function should revert if sender is not admin
@@ -48,19 +48,19 @@ contract AccessControlFacetTest is DiamondSetup {
                 uint256(DEFAULT_ADMIN_ROLE).toHexString(32)
             )
         );
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
     }
 
     // test revokeRole function should work only for admin
     function testRevokeRole_ShouldWork() public {
         vm.prank(admin);
         emit RoleGranted(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
 
         vm.prank(admin);
         vm.expectEmit(true, true, true, true);
         emit RoleRevoked(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessCtrl.revokeRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        IAccessControl.revokeRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
     }
 
     // test revokeRole function should revert if sender is not admin
@@ -75,7 +75,7 @@ contract AccessControlFacetTest is DiamondSetup {
                 uint256(DEFAULT_ADMIN_ROLE).toHexString(32)
             )
         );
-        IAccessCtrl.revokeRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        IAccessControl.revokeRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
     }
 
     // test renounceRole function should work for grantee
@@ -83,7 +83,7 @@ contract AccessControlFacetTest is DiamondSetup {
         vm.prank(admin);
         vm.expectEmit(true, true, true, true);
         emit RoleGranted(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
 
         vm.prank(mock_recipient);
         vm.expectEmit(true, true, true, true);
@@ -92,6 +92,6 @@ contract AccessControlFacetTest is DiamondSetup {
             mock_recipient,
             mock_recipient
         );
-        IAccessCtrl.renounceRole(GOVERNANCE_TOKEN_BURNER_ROLE);
+        IAccessControl.renounceRole(GOVERNANCE_TOKEN_BURNER_ROLE);
     }
 }

--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -29,7 +29,7 @@ contract BondingCurveFacetTest is DiamondSetup {
         super.setUp();
 
         vm.startPrank(admin);
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
 
         vm.stopPrank();
     }

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -19,7 +19,7 @@ import {MockCurveFactory} from "../../../src/dollar/mocks/MockCurveFactory.sol";
 contract ZeroStateChef is DiamondSetup {
     MockERC20 crvToken;
     address curve3CrvToken;
-    uint256 creditNFTLengthBlocks = 100;
+    uint256 creditNftLengthBlocks = 100;
     address treasury = address(0x3);
     address secondAccount = address(0x4);
     address thirdAccount = address(0x5);
@@ -98,7 +98,7 @@ contract ZeroStateChef is DiamondSetup {
         stakingShareV1 = new BondingShare(address(diamond));
         IManager.setStakingShareAddress(address(stakingShareV1));
         stakingShareV1.setApprovalForAll(address(diamond), true);
-        IAccessCtrl.grantRole(
+        IAccessControl.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(stakingShareV1)
         );
@@ -125,11 +125,11 @@ contract ZeroStateChef is DiamondSetup {
 
         vm.startPrank(admin);
 
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
-        IAccessCtrl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
+        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
 
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
         UbiquityCreditToken creditToken = new UbiquityCreditToken(
             address(IManager)
         );
@@ -175,7 +175,7 @@ contract ZeroStateChef is DiamondSetup {
         vm.startPrank(admin);
         stakingShare = new StakingShare(address(diamond), uri);
         IManager.setStakingShareAddress(address(stakingShare));
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
         IStakingFacet.setBlockCountInAWeek(420);
 
         vm.stopPrank();

--- a/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
@@ -22,7 +22,7 @@ contract CollectableDustFacetTest is DiamondSetup {
 
         vm.startPrank(admin);
 
-        IAccessCtrl.grantRole(STAKING_MANAGER_ROLE, stakingManager);
+        IAccessControl.grantRole(STAKING_MANAGER_ROLE, stakingManager);
 
         // deploy mock token
         mockToken = new MockERC20("Mock", "MCK", 18);

--- a/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
@@ -15,14 +15,14 @@ import {MockCreditToken} from "../../../src/dollar/mocks/MockCreditToken.sol";
 import {UbiquityCreditToken} from "../../../src/dollar/core/UbiquityCreditToken.sol";
 
 contract CreditNftManagerFacetTest is DiamondSetup {
-    MockCreditNft _creditNFT;
+    MockCreditNft _creditNft;
     address dollarManagerAddress;
     address dollarTokenAddress;
     address creditCalculatorAddress;
-    address creditNFTManagerAddress;
-    uint256 creditNFTLengthBlocks = 100;
+    address creditNftManagerAddress;
+    uint256 creditNftLengthBlocks = 100;
     address twapOracleAddress;
-    address creditNFTAddress;
+    address creditNftAddress;
     address governanceTokenAddress;
     address creditTokenAddress;
     address dollarMintCalculatorAddress;
@@ -34,15 +34,15 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         uint256 admSupply = IDollar.balanceOf(admin);
         assertEq(admSupply, 10000e18);
 
-        _creditNFT = new MockCreditNft(100);
+        _creditNft = new MockCreditNft(100);
         vm.prank(admin);
-        IManager.setCreditNftAddress(address(_creditNFT));
+        IManager.setCreditNftAddress(address(_creditNft));
 
         twapOracleAddress = address(diamond);
         dollarTokenAddress = address(IDollar);
-        creditNFTManagerAddress = address(diamond);
+        creditNftManagerAddress = address(diamond);
         creditCalculatorAddress = IManager.creditCalculatorAddress();
-        creditNFTAddress = address(_creditNFT);
+        creditNftAddress = address(_creditNft);
         governanceTokenAddress = IManager.governanceTokenAddress();
         // deploy credit token
         MockCreditToken _creditToken = new MockCreditToken(0);
@@ -52,7 +52,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
 
         // set this contract as minter
         vm.startPrank(admin);
-        IAccessCtrl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(this));
+        IAccessControl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(this));
         vm.stopPrank();
     }
 
@@ -78,28 +78,28 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         );
     }
 
-    function test_setExpiredCreditNFTConversionRate() public {
+    function test_setExpiredCreditNftConversionRate() public {
         vm.expectRevert("Caller is not a Credit NFT manager");
-        ICreditNFTMgrFacet.setExpiredCreditNFTConversionRate(100);
+        ICreditNftMgrFacet.setExpiredCreditNftConversionRate(100);
 
         vm.prank(admin);
-        ICreditNFTMgrFacet.setExpiredCreditNFTConversionRate(100);
-        assertEq(ICreditNFTMgrFacet.expiredCreditNFTConversionRate(), 100);
+        ICreditNftMgrFacet.setExpiredCreditNftConversionRate(100);
+        assertEq(ICreditNftMgrFacet.expiredCreditNftConversionRate(), 100);
     }
 
-    function test_setCreditNFTLength() public {
+    function test_setCreditNftLength() public {
         vm.expectRevert("Caller is not a Credit NFT manager");
-        ICreditNFTMgrFacet.setCreditNFTLength(100);
+        ICreditNftMgrFacet.setCreditNftLength(100);
 
         vm.prank(admin);
-        ICreditNFTMgrFacet.setCreditNFTLength(100);
-        assertEq(ICreditNFTMgrFacet.creditNFTLengthBlocks(), 100);
+        ICreditNftMgrFacet.setCreditNftLength(100);
+        assertEq(ICreditNftMgrFacet.creditNftLengthBlocks(), 100);
     }
 
-    function test_exchangeDollarsForCreditNFT() public {
+    function test_exchangeDollarsForCreditNft() public {
         mockTwapFuncs(2e18);
         vm.expectRevert("Price must be below 1 to mint Credit NFT");
-        ICreditNFTMgrFacet.exchangeDollarsForCreditNft(100);
+        ICreditNftMgrFacet.exchangeDollarsForCreditNft(100);
 
         mockTwapFuncs(5e17);
         address mockSender = address(0x123);
@@ -109,13 +109,13 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.startPrank(mockSender);
 
         MockDollarToken(dollarTokenAddress).approve(
-            creditNFTManagerAddress,
+            creditNftManagerAddress,
             10000e18
         );
 
-        uint256 expiryBlockNumber = ICreditNFTMgrFacet
+        uint256 expiryBlockNumber = ICreditNftMgrFacet
             .exchangeDollarsForCreditNft(100);
-        assertEq(expiryBlockNumber, 10000 + creditNFTLengthBlocks);
+        assertEq(expiryBlockNumber, 10000 + creditNftLengthBlocks);
     }
 
     function test_exchangeDollarsForCreditRevertsIfPriceHigherThan1Ether()
@@ -123,7 +123,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
     {
         mockTwapFuncs(2e18);
         vm.expectRevert("Price must be below 1 to mint Credit");
-        ICreditNFTMgrFacet.exchangeDollarsForCredit(100);
+        ICreditNftMgrFacet.exchangeDollarsForCredit(100);
     }
 
     function test_exchangeDollarsForCreditWorks() public {
@@ -134,28 +134,28 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.startPrank(mockSender);
 
         MockDollarToken(dollarTokenAddress).approve(
-            creditNFTManagerAddress,
+            creditNftManagerAddress,
             10000e18
         );
 
-        uint256 creditAmount = ICreditNFTMgrFacet.exchangeDollarsForCredit(100);
+        uint256 creditAmount = ICreditNftMgrFacet.exchangeDollarsForCredit(100);
         assertEq(creditAmount, 100);
     }
 
-    function test_burnExpiredCreditNFTForGovernanceRevertsIfNotExpired()
+    function test_burnExpiredCreditNftForGovernanceRevertsIfNotExpired()
         public
     {
         vm.roll(1000);
         vm.expectRevert("Credit NFT has not expired");
-        ICreditNFTMgrFacet.burnExpiredCreditNFTForGovernance(2000, 1e18);
+        ICreditNftMgrFacet.burnExpiredCreditNftForGovernance(2000, 1e18);
     }
 
-    function test_burnExpiredCreditNFTForGovernanceRevertsIfNotEnoughBalance()
+    function test_burnExpiredCreditNftForGovernanceRevertsIfNotEnoughBalance()
         public
     {
         address mockMessageSender = address(0x123);
         vm.prank(admin);
-        MockCreditNft(creditNFTAddress).mintCreditNft(
+        MockCreditNft(creditNftAddress).mintCreditNft(
             mockMessageSender,
             100,
             500
@@ -163,26 +163,26 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.roll(1000);
         vm.prank(mockMessageSender);
         vm.expectRevert("User not enough Credit NFT");
-        ICreditNFTMgrFacet.burnExpiredCreditNFTForGovernance(500, 1e18);
+        ICreditNftMgrFacet.burnExpiredCreditNftForGovernance(500, 1e18);
     }
 
-    function test_burnExpiredCreditNFTForGovernanceWorks() public {
+    function test_burnExpiredCreditNftForGovernanceWorks() public {
         address mockMessageSender = address(0x123);
         uint256 expiryBlockNumber = 500;
         vm.startPrank(admin);
-        MockCreditNft(creditNFTAddress).mintCreditNft(
+        MockCreditNft(creditNftAddress).mintCreditNft(
             mockMessageSender,
             2e18,
             expiryBlockNumber
         );
-        IAccessCtrl.grantRole(
+        IAccessControl.grantRole(
             keccak256("GOVERNANCE_TOKEN_MINTER_ROLE"),
-            creditNFTManagerAddress
+            creditNftManagerAddress
         );
         vm.stopPrank();
         vm.roll(1000);
         vm.prank(mockMessageSender);
-        ICreditNFTMgrFacet.burnExpiredCreditNFTForGovernance(
+        ICreditNftMgrFacet.burnExpiredCreditNftForGovernance(
             expiryBlockNumber,
             1e18
         );
@@ -191,35 +191,35 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         assertEq(governanceBalance, 5e17);
     }
 
-    function test_burnCreditNFTForCreditRevertsIfExpired() public {
+    function test_burnCreditNftForCreditRevertsIfExpired() public {
         vm.warp(1000);
         vm.expectRevert("Credit NFT has expired");
-        ICreditNFTMgrFacet.burnCreditNFTForCredit(500, 1e18);
+        ICreditNftMgrFacet.burnCreditNftForCredit(500, 1e18);
     }
 
-    function test_burnCreditNFTForCreditRevertsIfNotEnoughBalance() public {
+    function test_burnCreditNftForCreditRevertsIfNotEnoughBalance() public {
         vm.warp(1000);
         vm.expectRevert("User not enough Credit NFT");
-        ICreditNFTMgrFacet.burnCreditNFTForCredit(1001, 1e18);
+        ICreditNftMgrFacet.burnCreditNftForCredit(1001, 1e18);
     }
 
-    function test_burnCreditNFTForCreditWorks() public {
+    function test_burnCreditNftForCreditWorks() public {
         address mockMessageSender = address(0x123);
         uint256 expiryBlockNumber = 500;
         vm.startPrank(admin);
-        MockCreditNft(creditNFTAddress).mintCreditNft(
+        MockCreditNft(creditNftAddress).mintCreditNft(
             mockMessageSender,
             2e18,
             expiryBlockNumber
         );
-        IAccessCtrl.grantRole(
+        IAccessControl.grantRole(
             keccak256("GOVERNANCE_TOKEN_MINTER_ROLE"),
-            creditNFTManagerAddress
+            creditNftManagerAddress
         );
         vm.stopPrank();
         vm.prank(mockMessageSender);
         vm.warp(expiryBlockNumber - 1);
-        ICreditNFTMgrFacet.burnCreditNFTForCredit(expiryBlockNumber, 1e18);
+        ICreditNftMgrFacet.burnCreditNftForCredit(expiryBlockNumber, 1e18);
         uint256 redeemBalance = UbiquityCreditToken(creditTokenAddress)
             .balanceOf(mockMessageSender);
         assertEq(redeemBalance, 1e18);
@@ -230,13 +230,13 @@ contract CreditNftManagerFacetTest is DiamondSetup {
     {
         mockTwapFuncs(5e17);
         vm.expectRevert("Price must be above 1");
-        ICreditNFTMgrFacet.burnCreditTokensForDollars(100);
+        ICreditNftMgrFacet.burnCreditTokensForDollars(100);
     }
 
     function test_burnCreditTokensForDollarsIfNotEnoughBalance() public {
         mockTwapFuncs(2e18);
         vm.expectRevert("User doesn't have enough Credit pool tokens.");
-        ICreditNFTMgrFacet.burnCreditTokensForDollars(100);
+        ICreditNftMgrFacet.burnCreditTokensForDollars(100);
     }
 
     function test_burnCreditTokensForDollarsWorks() public {
@@ -245,30 +245,30 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         address account1 = address(0x123);
         MockCreditToken(creditTokenAddress).mint(account1, 100e18);
         vm.prank(account1);
-        uint256 unredeemed = ICreditNFTMgrFacet.burnCreditTokensForDollars(
+        uint256 unredeemed = ICreditNftMgrFacet.burnCreditTokensForDollars(
             10e18
         );
         assertEq(unredeemed, 10e18 - 1e18);
     }
 
-    function test_redeemCreditNFTRevertsIfPriceLowerThan1Ether() public {
+    function test_redeemCreditNftRevertsIfPriceLowerThan1Ether() public {
         mockTwapFuncs(5e17);
         vm.expectRevert("Price must be above 1 to redeem Credit NFT");
-        ICreditNFTMgrFacet.redeemCreditNft(123123123, 100);
+        ICreditNftMgrFacet.redeemCreditNft(123123123, 100);
     }
 
-    function test_redeemCreditNFTRevertsIfCreditNFTExpired() public {
+    function test_redeemCreditNftRevertsIfCreditNftExpired() public {
         mockTwapFuncs(2e18);
         vm.roll(10000);
         vm.expectRevert("Credit NFT has expired");
-        ICreditNFTMgrFacet.redeemCreditNft(5555, 100);
+        ICreditNftMgrFacet.redeemCreditNft(5555, 100);
     }
 
-    function test_redeemCreditNFTRevertsIfNotEnoughBalance() public {
+    function test_redeemCreditNftRevertsIfNotEnoughBalance() public {
         mockTwapFuncs(2e18);
         address account1 = address(0x123);
         uint256 expiryBlockNumber = 123123;
-        MockCreditNft(creditNFTAddress).mintCreditNft(
+        MockCreditNft(creditNftAddress).mintCreditNft(
             account1,
             100,
             expiryBlockNumber
@@ -276,24 +276,24 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.expectRevert("User not enough Credit NFT");
         vm.prank(account1);
         vm.roll(expiryBlockNumber - 1);
-        ICreditNFTMgrFacet.redeemCreditNft(expiryBlockNumber, 200);
+        ICreditNftMgrFacet.redeemCreditNft(expiryBlockNumber, 200);
     }
 
-    function test_redeemCreditNFTRevertsIfNotEnoughDollars() public {
+    function test_redeemCreditNftRevertsIfNotEnoughDollars() public {
         mockTwapFuncs(2e18);
         address account1 = address(0x123);
         uint256 expiryBlockNumber = 123123;
-        MockCreditNft(creditNFTAddress).mintCreditNft(
+        MockCreditNft(creditNftAddress).mintCreditNft(
             account1,
             100,
             expiryBlockNumber
         );
         MockCreditToken(creditTokenAddress).mint(
-            creditNFTManagerAddress,
+            creditNftManagerAddress,
             20000e18
         );
 
-        // set excess dollar distributor for creditNFTAddress
+        // set excess dollar distributor for creditNftAddress
         vm.mockCall(
             address(diamond),
             abi.encodeWithSelector(
@@ -305,22 +305,22 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.prank(account1);
         vm.expectRevert("There aren't enough Dollar to redeem currently");
         vm.roll(expiryBlockNumber - 1);
-        ICreditNFTMgrFacet.redeemCreditNft(expiryBlockNumber, 99);
+        ICreditNftMgrFacet.redeemCreditNft(expiryBlockNumber, 99);
     }
 
-    function test_redeemCreditNFTRevertsIfZeroAmountOfDollars() public {
+    function test_redeemCreditNftRevertsIfZeroAmountOfDollars() public {
         mockTwapFuncs(2e18);
         mockDollarMintCalcFuncs(0);
         address account1 = address(0x123);
         uint256 expiryBlockNumber = 123123;
-        MockCreditNft(creditNFTAddress).mintCreditNft(
+        MockCreditNft(creditNftAddress).mintCreditNft(
             account1,
             100,
             expiryBlockNumber
         );
-        // MockAutoRedeem(creditTokenAddress).mint(creditNFTManagerAddress, 20000e18);
+        // MockAutoRedeem(creditTokenAddress).mint(creditNftManagerAddress, 20000e18);
 
-        // set excess dollar distributor for creditNFTAddress
+        // set excess dollar distributor for creditNftAddress
 
         vm.mockCall(
             address(diamond),
@@ -333,21 +333,21 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.prank(account1);
         vm.expectRevert("There aren't any Dollar to redeem currently");
         vm.roll(expiryBlockNumber - 1);
-        ICreditNFTMgrFacet.redeemCreditNft(expiryBlockNumber, 99);
+        ICreditNftMgrFacet.redeemCreditNft(expiryBlockNumber, 99);
     }
 
-    function test_redeemCreditNFTWorks() public {
+    function test_redeemCreditNftWorks() public {
         mockTwapFuncs(2e18);
         mockDollarMintCalcFuncs(20000e18);
         address account1 = address(0x123);
         uint256 expiryBlockNumber = 123123;
-        MockCreditNft(creditNFTAddress).mintCreditNft(
+        MockCreditNft(creditNftAddress).mintCreditNft(
             account1,
             100,
             expiryBlockNumber
         );
         MockCreditToken(creditTokenAddress).mint(
-            creditNFTManagerAddress,
+            creditNftManagerAddress,
             10000e18
         );
 
@@ -361,16 +361,16 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         );
         vm.prank(account1);
         vm.roll(expiryBlockNumber - 1);
-        uint256 unredeemedCreditNFT = ICreditNFTMgrFacet.redeemCreditNft(
+        uint256 unredeemedCreditNft = ICreditNftMgrFacet.redeemCreditNft(
             expiryBlockNumber,
             99
         );
-        assertEq(unredeemedCreditNFT, 0);
+        assertEq(unredeemedCreditNft, 0);
     }
 
     function test_mintClaimableDollars() public {
         mockDollarMintCalcFuncs(50);
-        // set excess dollar distributor for creditNFTAddress
+        // set excess dollar distributor for creditNftAddress
 
         vm.mockCall(
             address(diamond),
@@ -381,11 +381,11 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         );
 
         uint256 beforeBalance = MockDollarToken(dollarTokenAddress).balanceOf(
-            creditNFTManagerAddress
+            creditNftManagerAddress
         );
-        ICreditNFTMgrFacet.mintClaimableDollars();
+        ICreditNftMgrFacet.mintClaimableDollars();
         uint256 afterBalance = MockDollarToken(dollarTokenAddress).balanceOf(
-            creditNFTManagerAddress
+            creditNftManagerAddress
         );
         assertEq(afterBalance - beforeBalance, 50);
     }

--- a/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
@@ -80,26 +80,26 @@ contract CreditNftManagerFacetTest is DiamondSetup {
 
     function test_setExpiredCreditNftConversionRate() public {
         vm.expectRevert("Caller is not a Credit NFT manager");
-        ICreditNftMgrFacet.setExpiredCreditNftConversionRate(100);
+        ICreditNftManagerFacet.setExpiredCreditNftConversionRate(100);
 
         vm.prank(admin);
-        ICreditNftMgrFacet.setExpiredCreditNftConversionRate(100);
-        assertEq(ICreditNftMgrFacet.expiredCreditNftConversionRate(), 100);
+        ICreditNftManagerFacet.setExpiredCreditNftConversionRate(100);
+        assertEq(ICreditNftManagerFacet.expiredCreditNftConversionRate(), 100);
     }
 
     function test_setCreditNftLength() public {
         vm.expectRevert("Caller is not a Credit NFT manager");
-        ICreditNftMgrFacet.setCreditNftLength(100);
+        ICreditNftManagerFacet.setCreditNftLength(100);
 
         vm.prank(admin);
-        ICreditNftMgrFacet.setCreditNftLength(100);
-        assertEq(ICreditNftMgrFacet.creditNftLengthBlocks(), 100);
+        ICreditNftManagerFacet.setCreditNftLength(100);
+        assertEq(ICreditNftManagerFacet.creditNftLengthBlocks(), 100);
     }
 
     function test_exchangeDollarsForCreditNft() public {
         mockTwapFuncs(2e18);
         vm.expectRevert("Price must be below 1 to mint Credit NFT");
-        ICreditNftMgrFacet.exchangeDollarsForCreditNft(100);
+        ICreditNftManagerFacet.exchangeDollarsForCreditNft(100);
 
         mockTwapFuncs(5e17);
         address mockSender = address(0x123);
@@ -113,7 +113,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
             10000e18
         );
 
-        uint256 expiryBlockNumber = ICreditNftMgrFacet
+        uint256 expiryBlockNumber = ICreditNftManagerFacet
             .exchangeDollarsForCreditNft(100);
         assertEq(expiryBlockNumber, 10000 + creditNftLengthBlocks);
     }
@@ -123,7 +123,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
     {
         mockTwapFuncs(2e18);
         vm.expectRevert("Price must be below 1 to mint Credit");
-        ICreditNftMgrFacet.exchangeDollarsForCredit(100);
+        ICreditNftManagerFacet.exchangeDollarsForCredit(100);
     }
 
     function test_exchangeDollarsForCreditWorks() public {
@@ -138,7 +138,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
             10000e18
         );
 
-        uint256 creditAmount = ICreditNftMgrFacet.exchangeDollarsForCredit(100);
+        uint256 creditAmount = ICreditNftManagerFacet.exchangeDollarsForCredit(100);
         assertEq(creditAmount, 100);
     }
 
@@ -147,7 +147,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
     {
         vm.roll(1000);
         vm.expectRevert("Credit NFT has not expired");
-        ICreditNftMgrFacet.burnExpiredCreditNftForGovernance(2000, 1e18);
+        ICreditNftManagerFacet.burnExpiredCreditNftForGovernance(2000, 1e18);
     }
 
     function test_burnExpiredCreditNftForGovernanceRevertsIfNotEnoughBalance()
@@ -163,7 +163,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.roll(1000);
         vm.prank(mockMessageSender);
         vm.expectRevert("User not enough Credit NFT");
-        ICreditNftMgrFacet.burnExpiredCreditNftForGovernance(500, 1e18);
+        ICreditNftManagerFacet.burnExpiredCreditNftForGovernance(500, 1e18);
     }
 
     function test_burnExpiredCreditNftForGovernanceWorks() public {
@@ -182,7 +182,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.stopPrank();
         vm.roll(1000);
         vm.prank(mockMessageSender);
-        ICreditNftMgrFacet.burnExpiredCreditNftForGovernance(
+        ICreditNftManagerFacet.burnExpiredCreditNftForGovernance(
             expiryBlockNumber,
             1e18
         );
@@ -194,13 +194,13 @@ contract CreditNftManagerFacetTest is DiamondSetup {
     function test_burnCreditNftForCreditRevertsIfExpired() public {
         vm.warp(1000);
         vm.expectRevert("Credit NFT has expired");
-        ICreditNftMgrFacet.burnCreditNftForCredit(500, 1e18);
+        ICreditNftManagerFacet.burnCreditNftForCredit(500, 1e18);
     }
 
     function test_burnCreditNftForCreditRevertsIfNotEnoughBalance() public {
         vm.warp(1000);
         vm.expectRevert("User not enough Credit NFT");
-        ICreditNftMgrFacet.burnCreditNftForCredit(1001, 1e18);
+        ICreditNftManagerFacet.burnCreditNftForCredit(1001, 1e18);
     }
 
     function test_burnCreditNftForCreditWorks() public {
@@ -219,7 +219,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.stopPrank();
         vm.prank(mockMessageSender);
         vm.warp(expiryBlockNumber - 1);
-        ICreditNftMgrFacet.burnCreditNftForCredit(expiryBlockNumber, 1e18);
+        ICreditNftManagerFacet.burnCreditNftForCredit(expiryBlockNumber, 1e18);
         uint256 redeemBalance = UbiquityCreditToken(creditTokenAddress)
             .balanceOf(mockMessageSender);
         assertEq(redeemBalance, 1e18);
@@ -230,13 +230,13 @@ contract CreditNftManagerFacetTest is DiamondSetup {
     {
         mockTwapFuncs(5e17);
         vm.expectRevert("Price must be above 1");
-        ICreditNftMgrFacet.burnCreditTokensForDollars(100);
+        ICreditNftManagerFacet.burnCreditTokensForDollars(100);
     }
 
     function test_burnCreditTokensForDollarsIfNotEnoughBalance() public {
         mockTwapFuncs(2e18);
         vm.expectRevert("User doesn't have enough Credit pool tokens.");
-        ICreditNftMgrFacet.burnCreditTokensForDollars(100);
+        ICreditNftManagerFacet.burnCreditTokensForDollars(100);
     }
 
     function test_burnCreditTokensForDollarsWorks() public {
@@ -245,7 +245,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         address account1 = address(0x123);
         MockCreditToken(creditTokenAddress).mint(account1, 100e18);
         vm.prank(account1);
-        uint256 unredeemed = ICreditNftMgrFacet.burnCreditTokensForDollars(
+        uint256 unredeemed = ICreditNftManagerFacet.burnCreditTokensForDollars(
             10e18
         );
         assertEq(unredeemed, 10e18 - 1e18);
@@ -254,14 +254,14 @@ contract CreditNftManagerFacetTest is DiamondSetup {
     function test_redeemCreditNftRevertsIfPriceLowerThan1Ether() public {
         mockTwapFuncs(5e17);
         vm.expectRevert("Price must be above 1 to redeem Credit NFT");
-        ICreditNftMgrFacet.redeemCreditNft(123123123, 100);
+        ICreditNftManagerFacet.redeemCreditNft(123123123, 100);
     }
 
     function test_redeemCreditNftRevertsIfCreditNftExpired() public {
         mockTwapFuncs(2e18);
         vm.roll(10000);
         vm.expectRevert("Credit NFT has expired");
-        ICreditNftMgrFacet.redeemCreditNft(5555, 100);
+        ICreditNftManagerFacet.redeemCreditNft(5555, 100);
     }
 
     function test_redeemCreditNftRevertsIfNotEnoughBalance() public {
@@ -276,7 +276,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.expectRevert("User not enough Credit NFT");
         vm.prank(account1);
         vm.roll(expiryBlockNumber - 1);
-        ICreditNftMgrFacet.redeemCreditNft(expiryBlockNumber, 200);
+        ICreditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 200);
     }
 
     function test_redeemCreditNftRevertsIfNotEnoughDollars() public {
@@ -305,7 +305,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.prank(account1);
         vm.expectRevert("There aren't enough Dollar to redeem currently");
         vm.roll(expiryBlockNumber - 1);
-        ICreditNftMgrFacet.redeemCreditNft(expiryBlockNumber, 99);
+        ICreditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 99);
     }
 
     function test_redeemCreditNftRevertsIfZeroAmountOfDollars() public {
@@ -333,7 +333,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         vm.prank(account1);
         vm.expectRevert("There aren't any Dollar to redeem currently");
         vm.roll(expiryBlockNumber - 1);
-        ICreditNftMgrFacet.redeemCreditNft(expiryBlockNumber, 99);
+        ICreditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 99);
     }
 
     function test_redeemCreditNftWorks() public {
@@ -361,7 +361,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         );
         vm.prank(account1);
         vm.roll(expiryBlockNumber - 1);
-        uint256 unredeemedCreditNft = ICreditNftMgrFacet.redeemCreditNft(
+        uint256 unredeemedCreditNft = ICreditNftManagerFacet.redeemCreditNft(
             expiryBlockNumber,
             99
         );
@@ -383,7 +383,7 @@ contract CreditNftManagerFacetTest is DiamondSetup {
         uint256 beforeBalance = MockDollarToken(dollarTokenAddress).balanceOf(
             creditNftManagerAddress
         );
-        ICreditNftMgrFacet.mintClaimableDollars();
+        ICreditNftManagerFacet.mintClaimableDollars();
         uint256 afterBalance = MockDollarToken(dollarTokenAddress).balanceOf(
             creditNftManagerAddress
         );

--- a/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
@@ -25,7 +25,7 @@ contract CreditNftRedemptionCalculatorFacetTest is DiamondSetup {
         );
 
         vm.expectRevert("CreditNft to Dollar: DEBT_TOO_HIGH");
-        ICreditNftRedCalcFacet.getCreditNftAmount(0);
+        ICreditNftRedemptionCalculationFacet.getCreditNftAmount(0);
     }
 
     function test_getCreditNftAmount() public {
@@ -33,6 +33,6 @@ contract CreditNftRedemptionCalculatorFacetTest is DiamondSetup {
         MockCreditNft(IManager.creditNftAddress()).setTotalOutstandingDebt(
             totalSupply / 2
         );
-        assertEq(ICreditNftRedCalcFacet.getCreditNftAmount(10000), 40000);
+        assertEq(ICreditNftRedemptionCalculationFacet.getCreditNftAmount(10000), 40000);
     }
 }

--- a/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
@@ -5,7 +5,7 @@ import "../DiamondTestSetup.sol";
 import {MockCreditNft} from "../../../src/dollar/mocks/MockCreditNft.sol";
 
 contract CreditNftRedemptionCalculatorFacetTest is DiamondSetup {
-    MockCreditNft _creditNFT;
+    MockCreditNft _creditNft;
 
     function setUp() public virtual override {
         super.setUp();
@@ -13,26 +13,26 @@ contract CreditNftRedemptionCalculatorFacetTest is DiamondSetup {
         IDollar.mint(admin, 10000e18);
         uint256 admSupply = IDollar.balanceOf(admin);
         assertEq(admSupply, 10000e18);
-        _creditNFT = new MockCreditNft(100);
+        _creditNft = new MockCreditNft(100);
         vm.prank(admin);
-        IManager.setCreditNftAddress(address(_creditNFT));
+        IManager.setCreditNftAddress(address(_creditNft));
     }
 
-    function test_getCreditNFTAmount_revertsIfDebtTooHigh() public {
+    function test_getCreditNftAmount_revertsIfDebtTooHigh() public {
         uint256 totalSupply = IDollar.totalSupply();
         MockCreditNft(IManager.creditNftAddress()).setTotalOutstandingDebt(
             totalSupply + 1
         );
 
-        vm.expectRevert("CreditNFT to Dollar: DEBT_TOO_HIGH");
-        ICreditNFTRedCalcFacet.getCreditNftAmount(0);
+        vm.expectRevert("CreditNft to Dollar: DEBT_TOO_HIGH");
+        ICreditNftRedCalcFacet.getCreditNftAmount(0);
     }
 
-    function test_getCreditNFTAmount() public {
+    function test_getCreditNftAmount() public {
         uint256 totalSupply = IDollar.totalSupply();
         MockCreditNft(IManager.creditNftAddress()).setTotalOutstandingDebt(
             totalSupply / 2
         );
-        assertEq(ICreditNFTRedCalcFacet.getCreditNftAmount(10000), 40000);
+        assertEq(ICreditNftRedCalcFacet.getCreditNftAmount(10000), 40000);
     }
 }

--- a/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
@@ -22,13 +22,13 @@ contract CreditRedemptionCalculatorFacetTest is DiamondSetup {
     function testSetConstant_ShouldRevert_IfCalledNotByAdmin() public {
         vm.prank(user1);
         vm.expectRevert("CreditCalc: not admin");
-        ICreditRedCalcFacet.setConstant(2 ether);
+        ICreditRedemptionCalculationFacet.setConstant(2 ether);
     }
 
     function testSetConstant_ShouldUpdateCoef() public {
         vm.prank(admin);
-        ICreditRedCalcFacet.setConstant(2 ether);
-        assertEq(ICreditRedCalcFacet.getConstant(), 2 ether);
+        ICreditRedemptionCalculationFacet.setConstant(2 ether);
+        assertEq(ICreditRedemptionCalculationFacet.getConstant(), 2 ether);
     }
 
     function testGetCreditAmount_ShouldRevert_IfDebtIsTooHigh() public {
@@ -38,11 +38,11 @@ contract CreditRedemptionCalculatorFacetTest is DiamondSetup {
             abi.encode(1)
         );
         vm.expectRevert("Credit to Dollar: DEBT_TOO_HIGH");
-        ICreditRedCalcFacet.getCreditAmount(1 ether, 10);
+        ICreditRedemptionCalculationFacet.getCreditAmount(1 ether, 10);
     }
 
     function testGetCreditAmount_ShouldReturnAmount() public {
-        uint256 amount = ICreditRedCalcFacet.getCreditAmount(1 ether, 10);
+        uint256 amount = ICreditRedemptionCalculationFacet.getCreditAmount(1 ether, 10);
         assertEq(amount, 9999999999999999999);
     }
 }

--- a/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
@@ -6,7 +6,7 @@ import {MockCreditNft} from "../../../src/dollar/mocks/MockCreditNft.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CreditRedemptionCalculatorFacetTest is DiamondSetup {
-    MockCreditNft _creditNFT;
+    MockCreditNft _creditNft;
 
     function setUp() public virtual override {
         super.setUp();
@@ -14,9 +14,9 @@ contract CreditRedemptionCalculatorFacetTest is DiamondSetup {
         IDollar.mint(admin, 10000e18);
         uint256 admSupply = IDollar.balanceOf(admin);
         assertEq(admSupply, 10000e18);
-        _creditNFT = new MockCreditNft(100);
+        _creditNft = new MockCreditNft(100);
         vm.prank(admin);
-        IManager.setCreditNftAddress(address(_creditNFT));
+        IManager.setCreditNftAddress(address(_creditNft));
     }
 
     function testSetConstant_ShouldRevert_IfCalledNotByAdmin() public {

--- a/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
@@ -30,7 +30,7 @@ contract CurveDollarIncentiveTest is DiamondSetup {
         twapOracleAddress = address(diamond);
 
         vm.startPrank(admin);
-        IAccessCtrl.grantRole(CURVE_DOLLAR_MANAGER_ROLE, managerAddr);
+        IAccessControl.grantRole(CURVE_DOLLAR_MANAGER_ROLE, managerAddr);
         MockDollarToken(IManager.dollarTokenAddress()).mint(
             mockSender,
             10000e18

--- a/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
@@ -30,7 +30,7 @@ contract ManagerFacetTest is DiamondSetup {
         assertEq(IManager.creditTokenAddress(), contract1);
     }
 
-    function testSetCreditNFTAddress_ShouldSucceed() public prankAs(admin) {
+    function testSetCreditNftAddress_ShouldSucceed() public prankAs(admin) {
         IManager.setCreditNftAddress(contract1);
         assertEq(IManager.creditNftAddress(), contract1);
     }
@@ -102,11 +102,11 @@ contract ManagerFacetTest is DiamondSetup {
 
     function testSetIncentiveToDollar_ShouldSucceed() public prankAs(admin) {
         assertEq(
-            IAccessCtrl.hasRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin),
+            IAccessControl.hasRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin),
             true
         );
         assertEq(
-            IAccessCtrl.hasRole(
+            IAccessControl.hasRole(
                 GOVERNANCE_TOKEN_MANAGER_ROLE,
                 address(diamond)
             ),
@@ -120,7 +120,7 @@ contract ManagerFacetTest is DiamondSetup {
         prankAs(admin)
     {
         assertEq(
-            IAccessCtrl.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, admin),
+            IAccessControl.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, admin),
             true
         );
     }
@@ -158,8 +158,8 @@ contract ManagerFacetTest is DiamondSetup {
         }
 
         address stakingV1Address = generateAddress("stakingV1", true, 10 ether);
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, stakingV1Address);
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, stakingV1Address);
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, stakingV1Address);
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, stakingV1Address);
 
         vm.stopPrank();
 

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -21,7 +21,7 @@ import "forge-std/Test.sol";
 
 contract ZeroStateStaking is DiamondSetup {
     MockERC20 crvToken;
-    uint256 creditNFTLengthBlocks = 100;
+    uint256 creditNftLengthBlocks = 100;
     address treasury = address(0x3);
     address secondAccount = address(0x4);
     address thirdAccount = address(0x5);
@@ -103,7 +103,7 @@ contract ZeroStateStaking is DiamondSetup {
         stakingShareV1 = new BondingShare(address(diamond));
         IManager.setStakingShareAddress(address(stakingShareV1));
         stakingShareV1.setApprovalForAll(address(diamond), true);
-        IAccessCtrl.grantRole(
+        IAccessControl.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(stakingShareV1)
         );
@@ -132,11 +132,11 @@ contract ZeroStateStaking is DiamondSetup {
 
         vm.startPrank(admin);
 
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
-        IAccessCtrl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
+        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
 
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
         UbiquityCreditToken creditToken = new UbiquityCreditToken(
             address(IManager)
         );
@@ -182,7 +182,7 @@ contract ZeroStateStaking is DiamondSetup {
         vm.startPrank(admin);
         stakingShare = new StakingShare(address(diamond), uri);
         IManager.setStakingShareAddress(address(stakingShare));
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
         IStakingFacet.setBlockCountInAWeek(420);
 
         vm.stopPrank();

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -75,7 +75,7 @@ contract UbiquityPoolFacetTest is DiamondSetup {
         stakingShareV1 = new BondingShare(address(diamond));
         IManager.setStakingShareAddress(address(stakingShareV1));
         stakingShareV1.setApprovalForAll(address(diamond), true);
-        IAccessCtrl.grantRole(
+        IAccessControl.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(stakingShareV1)
         );
@@ -103,11 +103,11 @@ contract UbiquityPoolFacetTest is DiamondSetup {
 
         vm.startPrank(admin);
 
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
-        IAccessCtrl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
+        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(diamond));
 
-        IAccessCtrl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
+        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, address(diamond));
         UbiquityCreditToken creditToken = new UbiquityCreditToken(
             address(IManager)
         );

--- a/packages/contracts/test/dollar/core/StakingShare.t.sol
+++ b/packages/contracts/test/dollar/core/StakingShare.t.sol
@@ -38,7 +38,7 @@ contract DepositStakingShare is LocalTestHelper {
         super.setUp();
         // grant diamond token staking share right rights
         vm.prank(admin);
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
         metapool = IMetaPool(metaPoolAddress);
         fourthBal = metapool.balanceOf(fourthAccount);
         minBal = metapool.balanceOf(stakingMinAccount);
@@ -83,7 +83,7 @@ contract StakingShareTest is DepositStakingShare {
         uint256 end
     ) public {
         vm.prank(admin);
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
         vm.prank(admin);
         stakingShare.updateStake(1, uint256(amount), uint256(debt), end);
         StakingShare.Stake memory stake = stakingShare.getStake(1);
@@ -121,7 +121,7 @@ contract StakingShareTest is DepositStakingShare {
         uint256 end
     ) public {
         vm.prank(admin);
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
         vm.prank(admin);
         uint256 id = stakingShare.mint(
             secondAccount,
@@ -176,33 +176,33 @@ contract StakingShareTest is DepositStakingShare {
         emit Paused(admin);
 
         vm.prank(admin);
-        IAccessCtrl.pause();
+        IAccessControl.pause();
     }
 
     function testPause_ShouldRevert_IfNotPauser() public {
         vm.expectRevert("Manager: Caller is not admin");
         vm.prank(secondAccount);
-        IAccessCtrl.pause();
+        IAccessControl.pause();
     }
 
     function testUnpause_ShouldUnpause() public {
         vm.prank(admin);
-        IAccessCtrl.pause();
+        IAccessControl.pause();
 
         vm.expectEmit(true, false, false, true);
         emit Unpaused(admin);
 
         vm.prank(admin);
-        IAccessCtrl.unpause();
+        IAccessControl.unpause();
     }
 
     function testUnpause_ShouldRevert_IfNotPauser() public {
         vm.prank(admin);
-        IAccessCtrl.pause();
+        IAccessControl.pause();
 
         vm.expectRevert("Manager: Caller is not admin");
         vm.prank(secondAccount);
-        IAccessCtrl.unpause();
+        IAccessControl.unpause();
     }
 
     function testSafeTransferFrom_ShouldTransferTokenId() public {
@@ -329,7 +329,7 @@ contract StakingShareTest is DepositStakingShare {
 
     function testSetUri_ShouldSetUri() public {
         vm.prank(admin);
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
 
         string memory stringTest = "{'name':'Staking Share','description':,"
         "'Ubiquity Staking Share',"
@@ -345,7 +345,7 @@ contract StakingShareTest is DepositStakingShare {
 
     function testSetBaseUri_ShouldSetUri() public {
         vm.prank(admin);
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
 
         string memory stringTest = "{'name':'Staking Share','description':,"
         "'Ubiquity Staking Share',"
@@ -361,7 +361,7 @@ contract StakingShareTest is DepositStakingShare {
 
     function testSetUriSingle_ShouldSetUri() public {
         vm.prank(admin);
-        IAccessCtrl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
 
         string memory stringTest = "{'name':'Staking Share','description':,"
         "'Ubiquity Staking Share',"

--- a/packages/contracts/test/dollar/core/UbiquityDollarToken.t.sol
+++ b/packages/contracts/test/dollar/core/UbiquityDollarToken.t.sol
@@ -26,7 +26,7 @@ contract UbiquityDollarTokenTest is LocalTestHelper {
         vm.startPrank(admin);
         dollar_addr = address(IDollar);
 
-        IAccessCtrl.grantRole(
+        IAccessControl.grantRole(
             keccak256("GOVERNANCE_TOKEN_MANAGER_ROLE"),
             admin
         );

--- a/packages/contracts/test/dollar/core/UbiquityGovernanceToken.t.sol
+++ b/packages/contracts/test/dollar/core/UbiquityGovernanceToken.t.sol
@@ -13,7 +13,7 @@ contract UbiquityGovernanceTokenTest is LocalTestHelper {
     function setUp() public override {
         super.setUp();
         vm.startPrank(admin);
-        IAccessCtrl.grantRole(
+        IAccessControl.grantRole(
             keccak256("GOVERNANCE_TOKEN_MANAGER_ROLE"),
             admin
         );

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -46,10 +46,10 @@ abstract contract LocalTestHelper is DiamondSetup {
         super.setUp();
 
         twapOracle = ITWAPOracleDollar3pool;
-        creditNftRedemptionCalculator = ICreditNFTRedCalcFacet;
+        creditNftRedemptionCalculator = ICreditNftRedCalcFacet;
         creditRedemptionCalculator = ICreditRedCalcFacet;
         dollarMintCalculator = IDollarMintCalcFacet;
-        creditNftManager = ICreditNFTMgrFacet;
+        creditNftManager = ICreditNftMgrFacet;
         dollarMintExcess = IDollarMintExcessFacet;
 
         vm.startPrank(admin);

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -46,10 +46,10 @@ abstract contract LocalTestHelper is DiamondSetup {
         super.setUp();
 
         twapOracle = ITWAPOracleDollar3pool;
-        creditNftRedemptionCalculator = ICreditNftRedCalcFacet;
-        creditRedemptionCalculator = ICreditRedCalcFacet;
+        creditNftRedemptionCalculator = ICreditNftRedemptionCalculationFacet;
+        creditRedemptionCalculator = ICreditRedemptionCalculationFacet;
         dollarMintCalculator = IDollarMintCalcFacet;
-        creditNftManager = ICreditNftMgrFacet;
+        creditNftManager = ICreditNftManagerFacet;
         dollarMintExcess = IDollarMintExcessFacet;
 
         vm.startPrank(admin);

--- a/packages/dapp/components/utils/local-data.ts
+++ b/packages/dapp/components/utils/local-data.ts
@@ -37,8 +37,8 @@ export async function fetchData() {
 
     // NFTAddress
     const NFTMinter = ethers.Wallet.createRandom().address;
-    const CreditNFTFacet = getDebtCouponContract(await diamondContract.creditNftAddress(), provider);
-    const CreditNFTManager = getDebtCouponManagerContract(diamondAddress, provider);
+    const CreditNftFacet = getDebtCouponContract(await diamondContract.creditNftAddress(), provider);
+    const CreditNftManager = getDebtCouponManagerContract(diamondAddress, provider);
     const TWAPOracle = getTWAPOracleContract(await diamondContract.twapOracleAddress(), provider);
 
     {
@@ -55,19 +55,19 @@ export async function fetchData() {
         console.log(await diamondContract.creditNftAddress(), "Credit NFT Address");
 
         // Needs dynamism and more debugging but works mints and burns!
-        console.log((await CreditNFTFacet.connect(signer).mintCreditNft(signer.getAddress(), "1", 2000000 + 300)).hash);
-        console.log((await CreditNFTFacet.connect(signer).burnCreditNft(signer.getAddress(), 0, "1000000")).hash);
+        console.log((await CreditNftFacet.connect(signer).mintCreditNft(signer.getAddress(), "1", 2000000 + 300)).hash);
+        console.log((await CreditNftFacet.connect(signer).burnCreditNft(signer.getAddress(), 0, "1000000")).hash);
 
-        console.log((await CreditNFTFacet.totalSupply()).toBigInt(), "Credit NFT Total Supply");
-        console.log((await CreditNFTFacet.balanceOf(signer.getAddress(), "0")).toBigInt(), "Credit NFT Balance");
-        console.log((await CreditNFTFacet.holderTokens(signer.getAddress())).toString(), "Credit Holders");
+        console.log((await CreditNftFacet.totalSupply()).toBigInt(), "Credit NFT Total Supply");
+        console.log((await CreditNftFacet.balanceOf(signer.getAddress(), "0")).toBigInt(), "Credit NFT Balance");
+        console.log((await CreditNftFacet.holderTokens(signer.getAddress())).toString(), "Credit Holders");
 
         // Diamond Address
-        console.log(await CreditNFTFacet.getManager(), "Manager");
+        console.log(await CreditNftFacet.getManager(), "Manager");
 
-        console.log((await CreditNFTManager.connect(signer).getCreditNFTReturnedForDollars(signer.getAddress())).toBigInt(), "Credit NFT Returned Dollars");
+        console.log((await CreditNftManager.connect(signer).getCreditNftReturnedForDollars(signer.getAddress())).toBigInt(), "Credit NFT Returned Dollars");
 
-        // Call CreditNFT ManagerFacet
+        // Call CreditNft ManagerFacet
         console.log("Anvil Block Number", block);
         console.log("Connected to Chain ID", LOCAL_CHAIN);
 
@@ -116,10 +116,10 @@ export async function fetchData() {
     console.log("%c" + TWAPOracle.address, "color: yellow", "twap address");
 
     // Working
-    console.log((await CreditNFTManager.connect(signer).setExpiredCreditNFTConversionRate(100)).hash, "Set Expired Credit NFT Conversion");
-    console.log((await CreditNFTManager.connect(signer).expiredCreditNFTConversionRate()).toBigInt(), "Expired Credit NFT Conversion Rate");
-    console.log((await CreditNFTManager.connect(signer).setCreditNFTLength(1000000000)).hash, "Set Credit NFT Length Blocks");
-    console.log((await CreditNFTManager.connect(signer).creditNFTLengthBlocks()).toBigInt(), "Credit NFT Length Blocks");
+    console.log((await CreditNftManager.connect(signer).setExpiredCreditNftConversionRate(100)).hash, "Set Expired Credit NFT Conversion");
+    console.log((await CreditNftManager.connect(signer).expiredCreditNftConversionRate()).toBigInt(), "Expired Credit NFT Conversion Rate");
+    console.log((await CreditNftManager.connect(signer).setCreditNftLength(1000000000)).hash, "Set Credit NFT Length Blocks");
+    console.log((await CreditNftManager.connect(signer).creditNftLengthBlocks()).toBigInt(), "Credit NFT Length Blocks");
 
     // Caller
     console.log(await signer.getAddress(), "Caller Address");


### PR DESCRIPTION
Resolves #736 
fix: Renamed 
CreditNFT's all .sol instance to CreditNft
creditNFT's all .sol instance to creditNft
accessCtrl's all .sol instance to accessControl
AccessCtrl's all .sol instance to AccessControl
Applied check for CreditNFT and creditNFT in cspell
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
