### PR TITLE
ci: run slither check on .sol files update

### DIFF
--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -4,7 +4,11 @@ on:
     branches:
       - development
       - main
+    paths:
+      - '**.sol'
   pull_request:
+    paths:
+      - '**.sol'
 
 jobs:
   slither-analysis:


### PR DESCRIPTION
Slither workflow runs for ~15min. We don't really need it to run on each PR or on push to the `development` branch. We should run it only when `.sol` files are updated. 

This PR modifies slither workflow to run only when solidity files are updated.
