### PR TITLE
ci: disable docs generation for forks

### DIFF
--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   generate-doc:
     name: Generate Doc
+    if: github.repository == 'ubiquity/ubiquity-dollar'
     runs-on: ubuntu-22.04
     permissions:
       contents: write


### PR DESCRIPTION
Right now when you sync a fork docs are generated again (in a forked repo) so on each fork sync you should revert the latest commit with the updated docs.

This PR runs docs generation job only for the https://github.com/ubiquity/ubiquity-dollar repository.
