### PR TITLE
Revamp regex to fix CodeQL scanning security (& performance) fix

### DIFF
--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -93,7 +93,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
   }
   if (stdout) {
     //test regex
-    const regex = /[^{}]*(?:R[^{}]*)*}/g;
+    const regex = /[^{}]*+(?:R[^{}]*+)*+}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -92,7 +92,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
     stderr = err?.stderr;
   }
   if (stdout) {
-    const regex = /{(?:[^{}]*|(R))*}/g;
+    const regex = /[^{}]*(?:(R)[^{}]*)*}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -93,7 +93,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
   }
   if (stdout) {
     //test regex
-    const regex = /[^{}]*(?:R[^{}]*)*}/g;    ;
+    const regex = /[^{}]*(?:R[^{}]*)*}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -92,6 +92,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
     stderr = err?.stderr;
   }
   if (stdout) {
+    //test regex
     const regex = /[^{}]*(?:(R)[^{}]*)*}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -92,7 +92,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
     stderr = err?.stderr;
   }
   if (stdout) {
-    const regex = /{(?:[^{}]*+(?:{[^{}]*+}[^{}]*)*+|(R))*+}/g;
+    const regex = /{(?:[^{}]*|R)*}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -92,7 +92,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
     stderr = err?.stderr;
   }
   if (stdout) {
-    const regex = /{(?:R*)*}/g;
+    const regex = /{[^{}]*}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -93,7 +93,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
   }
   if (stdout) {
     //test regex
-    const regex = /[^{}]*(?:(R)[^{}]*)*}/g;
+    const regex = /[^{}]*(?:R[^{}]*)*}/g;    ;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -92,7 +92,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
     stderr = err?.stderr;
   }
   if (stdout) {
-    const regex = /{(?:[^{}]*|R)*}/g;
+    const regex = /{(?:R*)*}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -92,8 +92,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
     stderr = err?.stderr;
   }
   if (stdout) {
-    //test regex
-    const regex = /[^{}]*+(?:R[^{}]*+)*+}/g;
+    const regex = /{(?:[^{}]*+(?:{[^{}]*+}[^{}]*)*+|(R))*+}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {
       const { deployedTo, deployer, transactionHash } = JSON.parse(found[0]);

--- a/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
+++ b/packages/contracts/scripts/deploy/manager/diamond-in-all.ts
@@ -92,6 +92,7 @@ const create = async (args: ForgeArguments): Promise<{ result: DeploymentResult 
     stderr = err?.stderr;
   }
   if (stdout) {
+    //debug regex
     const regex = /{[^{}]*}/g;
     const found = stdout.match(regex);
     if (found && JSON.parse(found[0])?.deployedTo) {


### PR DESCRIPTION
Resolves #746

as per github security and the Code QL action, it checks the regex that it's prone to degrade performance. This should fix it, but we will still take a look on the security tab and make sure it's gone

This update, does not interfere, with `deploy:development`