### PR TITLE
ci: update foundry

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-cc5637a979050c39b3d06bc4cc6134f0591ee8d0
+          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
 
       - name: Install dependencies
         run: sudo apt-get install lcov

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-cc5637a979050c39b3d06bc4cc6134f0591ee8d0
+          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts


### PR DESCRIPTION
The latest nightly foundry build introduced a [bug](https://github.com/foundry-rs/foundry/issues/5601) where tests are running too long (check [this CI run](https://github.com/ubiquity/ubiquity-dollar/actions/runs/5833687631)).

This PR updates foundry build for the version from July 2023