### PR TITLE
ci: generate docs only on sol files update

### DIFF
--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - development
+    paths:
+      - '**.sol'
 
 jobs:
   generate-doc:


### PR DESCRIPTION
Right now solidity natspec docs are generated on every push to the `development` branch which is really necessary when `.sol` files are updated

So this PR makes sure that docs are regenerated only when `.sol` files are updated