### PR TITLE
Refactor/move ubiquistick

### DIFF
--- a/packages/contracts/src/dollar/core/ERC1155Ubiquity.sol
+++ b/packages/contracts/src/dollar/core/ERC1155Ubiquity.sol
@@ -18,7 +18,7 @@ import "../../../src/dollar/utils/SafeAddArray.sol";
  * - TotalSupply per id
  * - Ubiquity Manager access control
  */
-contract ERC1155Ubiquity is
+abstract contract ERC1155Ubiquity is
     Initializable,
     ERC1155BurnableUpgradeable,
     ERC1155PausableUpgradeable,
@@ -84,7 +84,7 @@ contract ERC1155Ubiquity is
     function __ERC1155Ubiquity_init(
         address _manager,
         string memory _uri
-    ) public initializer onlyInitializing {
+    ) internal onlyInitializing {
         // init base contracts
         __ERC1155_init(_uri);
         __ERC1155Burnable_init();
@@ -98,7 +98,7 @@ contract ERC1155Ubiquity is
     /// @param _manager Address of the manager of the contract
     function __ERC1155Ubiquity_init_unchained(
         address _manager
-    ) public initializer onlyInitializing {
+    ) internal onlyInitializing {
         accessControl = IAccessControl(_manager);
     }
 

--- a/packages/contracts/src/dollar/libraries/LibBondingCurve.sol
+++ b/packages/contracts/src/dollar/libraries/LibBondingCurve.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import {LibAppStorage} from "./LibAppStorage.sol";
+import {UbiquiStick} from "../../ubiquistick/UbiquiStick.sol";
 import "../../ubiquistick/interfaces/IUbiquiStick.sol";
 import "../interfaces/IERC1155Ubiquity.sol";
 import "./Constants.sol";
@@ -132,14 +133,13 @@ library LibBondingCurve {
         dollar.transferFrom(_recipient, address(this), _collateralDeposited);
 
         ss.poolBalance = ss.poolBalance + _collateralDeposited;
-        bytes memory tokReturned = toBytes(tokensReturned);
         ss.share[_recipient] += tokensReturned;
         ss.tokenIds += 1;
 
-        IERC1155Ubiquity bNFT = IERC1155Ubiquity(
+        UbiquiStick ubiquiStick = UbiquiStick(
             LibAppStorage.appStorage().ubiquiStickAddress
         );
-        bNFT.mint(_recipient, ss.tokenIds, tokensReturned, tokReturned);
+        ubiquiStick.batchSafeMint(_recipient, tokensReturned);
 
         emit Deposit(_recipient, _collateralDeposited);
     }

--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -4,7 +4,9 @@ pragma solidity 0.8.19;
 import "../DiamondTestSetup.sol";
 import "../../../src/dollar/libraries/Constants.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {MockERC20} from "../../../src/dollar/mocks/MockERC20.sol";
+import {ERC1155Ubiquity} from "../../../src/dollar/core/ERC1155Ubiquity.sol";
 import "forge-std/Test.sol";
 
 contract BondingCurveFacetTest is DiamondSetup {
@@ -32,6 +34,22 @@ contract BondingCurveFacetTest is DiamondSetup {
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
+
+        // deploy UbiquiStick
+        bytes memory initData = abi.encodeWithSignature(
+            "__ERC1155Ubiquity_init(address,string)",
+            diamond,
+            ""
+        );
+        ERC1967Proxy proxyUbiquiStick = new ERC1967Proxy(
+            address(new ERC1155Ubiquity()),
+            initData
+        );
+        ERC1155Ubiquity ubiquiStick = ERC1155Ubiquity(
+            address(proxyUbiquiStick)
+        );
+
+        IManager.setUbiquistickAddress(address(ubiquiStick));
 
         vm.stopPrank();
     }

--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {MockERC20} from "../../../src/dollar/mocks/MockERC20.sol";
 import {ERC1155Ubiquity} from "../../../src/dollar/core/ERC1155Ubiquity.sol";
+import {UbiquiStick} from "../../../src/ubiquistick/UbiquiStick.sol";
 import "forge-std/Test.sol";
 
 contract BondingCurveFacetTest is DiamondSetup {
@@ -30,25 +31,15 @@ contract BondingCurveFacetTest is DiamondSetup {
         super.setUp();
 
         vm.startPrank(admin);
+
         IAccessControl.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
 
         // deploy UbiquiStick
-        bytes memory initData = abi.encodeWithSignature(
-            "__ERC1155Ubiquity_init(address,string)",
-            diamond,
-            ""
-        );
-        ERC1967Proxy proxyUbiquiStick = new ERC1967Proxy(
-            address(new ERC1155Ubiquity()),
-            initData
-        );
-        ERC1155Ubiquity ubiquiStick = ERC1155Ubiquity(
-            address(proxyUbiquiStick)
-        );
-
+        UbiquiStick ubiquiStick = new UbiquiStick();
+        ubiquiStick.setMinter(address(diamond));
         IManager.setUbiquistickAddress(address(ubiquiStick));
 
         vm.stopPrank();

--- a/packages/contracts/test/helpers/UUPSTestHelper.sol
+++ b/packages/contracts/test/helpers/UUPSTestHelper.sol
@@ -8,7 +8,6 @@ import {UbiquityCreditToken} from "../../src/dollar/core/UbiquityCreditToken.sol
 import {StakingShare} from "../../src/dollar/core/StakingShare.sol";
 import {CreditNft} from "../../src/dollar/core/CreditNft.sol";
 import {ManagerFacet} from "../../src/dollar/facets/ManagerFacet.sol";
-import {ERC1155Ubiquity} from "../../src/dollar/core/ERC1155Ubiquity.sol";
 import "../../src/dollar/libraries/Constants.sol";
 import "forge-std/Test.sol";
 
@@ -27,7 +26,6 @@ contract UUPSTestHelper {
     UbiquityCreditToken creditToken;
     UbiquityDollarToken dollarToken;
     UbiquityGovernanceToken governanceToken;
-    ERC1155Ubiquity ubiquiStick;
 
     // proxies for core contracts
     ERC1967Proxy proxyCreditNft;
@@ -88,22 +86,8 @@ contract UUPSTestHelper {
             address(proxyGovernanceToken)
         );
 
-        // deploy UbiquiStick (not a core contract, not upgradeable)
-        // TODO: move from UUPSTestHelper to a more relevant place
-        initData = abi.encodeWithSignature(
-            "__ERC1155Ubiquity_init(address,string)",
-            diamond,
-            uri
-        );
-        proxyUbiquiStick = new ERC1967Proxy(
-            address(new ERC1155Ubiquity()),
-            initData
-        );
-        ubiquiStick = ERC1155Ubiquity(address(proxyUbiquiStick));
-
         // set addresses of the newly deployed contracts in the Diamond
         ManagerFacet managerFacet = ManagerFacet(diamond);
-        managerFacet.setUbiquistickAddress(address(ubiquiStick));
         managerFacet.setStakingShareAddress(address(stakingShare));
         managerFacet.setCreditTokenAddress(address(creditToken));
         managerFacet.setDollarTokenAddress(address(dollarToken));


### PR DESCRIPTION
This PR:
1. Moves [UbiquiStick](https://github.com/ubiquity/ubiquity-dollar/blob/bd43faed27ae8e6a7864eb032ef10fbd3cb3e5f1/packages/contracts/src/ubiquistick/UbiquiStick.sol) deploy from [UUPSTestHelper](https://github.com/rndquu/ubiquity-dollar/blob/d425427efac58a518bacf8c587aa3cea0f38fb4e/packages/contracts/test/helpers/UUPSTestHelper.sol) to a single test where it is used
2. Fixes [bug](https://github.com/ubiquity/ubiquity-dollar/compare/development...rndquu:refactor/move-ubiquistick?expand=1#diff-76ab809b78554fd91239094e686b7e1815a9b5a386ac1807684a148a71eee3bdR142) when ERC1155 tokens are minted instead of ERC721 UbiquiStick
3. Makes [ERC1155Ubiquity](https://github.com/ubiquity/ubiquity-dollar/compare/development...rndquu:refactor/move-ubiquistick?expand=1#diff-4ee42a245546eec2c29ec9ac1f87501c5f4004a7cebf863852ca9df290fe1d7aR21) contract abstract to be on par with [ERC20Ubiquity](https://github.com/ubiquity/ubiquity-dollar/blob/bd43faed27ae8e6a7864eb032ef10fbd3cb3e5f1/packages/contracts/src/dollar/core/ERC20Ubiquity.sol)

Test coverage CI is failing but there are only code refactors.

Storage Check CI is also failing with the `API rate limit` error. Not sure what's causing it, I'll check it. Anyway this PR doesn't modify storage in any of the contracts.