### PR TITLE
ci: using foundry from 2 Oct 2023

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
+          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
+          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
+          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
+          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
 
       - name: Install dependencies
         run: sudo apt-get install lcov

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
+          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Install dependencies
         run: sudo apt-get install lcov

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
+          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
 
       - name: Install dependencies
         run: sudo apt-get install lcov

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
+          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
 
       - name: Forge install
         working-directory: packages/contracts

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
+          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Forge install
         working-directory: packages/contracts

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
+          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
 
       - name: Forge install
         working-directory: packages/contracts

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
+          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-ddca274340319fbd264dfa019a6de2a8146f50f6
+          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
+          version: nightly-96ab9131e6735df35aca0249968c7d339590de20
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts


### PR DESCRIPTION
This PR sets foundry toolchain action for the [version](https://github.com/foundry-rs/foundry/releases/tag/nightly-96ab9131e6735df35aca0249968c7d339590de20) dated on 28 Sep 2023. 

This is the closest release with the [vm.parseJsonKeys](https://github.com/foundry-rs/forge-std/commit/c0c6a4206531a3f785538240412ea2467ef58ebf) feature (which is needed for this [issue](https://github.com/ubiquity/ubiquity-dollar/issues/616)).

Chances are that this [release](https://github.com/foundry-rs/foundry/releases/tag/nightly-96ab9131e6735df35aca0249968c7d339590de20) will be removed in the future (because it is pretty much a fresh one and foundry tends to delete releases from time to time) but I haven't found any other ones with the `vm.parseJsonKeys` feature.