### PR TITLE
Refactor/diamond test naming

### DIFF
--- a/packages/contracts/test/diamond/DiamondTest.t.sol
+++ b/packages/contracts/test/diamond/DiamondTest.t.sol
@@ -17,9 +17,8 @@ contract TestDiamond is DiamondTestSetup {
 
     function testFacetsHaveCorrectSelectors() public {
         for (uint256 i = 0; i < facetAddressList.length; i++) {
-            bytes4[] memory fromLoupeFacet = ILoupe.facetFunctionSelectors(
-                facetAddressList[i]
-            );
+            bytes4[] memory fromLoupeFacet = diamondLoupeFacet
+                .facetFunctionSelectors(facetAddressList[i]);
             if (compareStrings(facetNames[i], "DiamondCutFacet")) {
                 assertTrue(
                     sameMembers(fromLoupeFacet, selectorsOfDiamondCutFacet)
@@ -46,28 +45,36 @@ contract TestDiamond is DiamondTestSetup {
                 for (uint256 j; j < selectorsOfDiamondCutFacet.length; j++) {
                     assertEq(
                         facetAddressList[i],
-                        ILoupe.facetAddress(selectorsOfDiamondCutFacet[j])
+                        diamondLoupeFacet.facetAddress(
+                            selectorsOfDiamondCutFacet[j]
+                        )
                     );
                 }
             } else if (compareStrings(facetNames[i], "DiamondLoupeFacet")) {
                 for (uint256 j; j < selectorsOfDiamondLoupeFacet.length; j++) {
                     assertEq(
                         facetAddressList[i],
-                        ILoupe.facetAddress(selectorsOfDiamondLoupeFacet[j])
+                        diamondLoupeFacet.facetAddress(
+                            selectorsOfDiamondLoupeFacet[j]
+                        )
                     );
                 }
             } else if (compareStrings(facetNames[i], "OwnershipFacet")) {
                 for (uint256 j; j < selectorsOfOwnershipFacet.length; j++) {
                     assertEq(
                         facetAddressList[i],
-                        ILoupe.facetAddress(selectorsOfOwnershipFacet[j])
+                        diamondLoupeFacet.facetAddress(
+                            selectorsOfOwnershipFacet[j]
+                        )
                     );
                 }
             } else if (compareStrings(facetNames[i], "ManagerFacet")) {
                 for (uint256 j; j < selectorsOfManagerFacet.length; j++) {
                     assertEq(
                         facetAddressList[i],
-                        ILoupe.facetAddress(selectorsOfManagerFacet[j])
+                        diamondLoupeFacet.facetAddress(
+                            selectorsOfManagerFacet[j]
+                        )
                     );
                 }
             }

--- a/packages/contracts/test/diamond/DiamondTest.t.sol
+++ b/packages/contracts/test/diamond/DiamondTest.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import "./DiamondTestSetup.sol";
 
-contract TestDiamond is DiamondSetup {
+contract TestDiamond is DiamondTestSetup {
     function test_ShouldSupportInspectingFacetsAndFunctions() public {
         bool isSupported = IERC165(address(diamond)).supportsInterface(
             type(IDiamondLoupe).interfaceId

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -110,9 +110,9 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
     /// @notice Deploys diamond and connects facets
     function setUp() public virtual {
+        // setup helper addresses
         owner = generateAddress("Owner", false, 10 ether);
         admin = generateAddress("Admin", false, 10 ether);
-
         user1 = generateAddress("User1", false, 10 ether);
         contract1 = generateAddress("Contract1", true, 10 ether);
         contract2 = generateAddress("Contract2", true, 10 ether);
@@ -563,50 +563,48 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
             (dollarMintExcessFacetImplementation.distributeDollars.selector)
         );
 
-        //deploy facets
-        diamondCutFacetImplementation = new DiamondCutFacet();
-        diamondLoupeFacetImplementation = new DiamondLoupeFacet();
-        ownershipFacetImplementation = new OwnershipFacet();
-        managerFacetImplementation = new ManagerFacet();
+        // deploy facet implementation instances
         accessControlFacetImplementation = new AccessControlFacet();
-        twapOracleDollar3PoolFacetImplementation = new TWAPOracleDollar3poolFacet();
-        collectableDustFacetImplementation = new CollectableDustFacet();
-        chefFacetImplementation = new ChefFacet();
-        stakingFacetImplementation = new StakingFacet();
-        ubiquityPoolFacetImplementation = new UbiquityPoolFacet();
-        stakingFormulasFacetImplementation = new StakingFormulasFacet();
         bondingCurveFacetImplementation = new BondingCurveFacet();
-        curveDollarIncentiveFacetImplementation = new CurveDollarIncentiveFacet();
-
+        chefFacetImplementation = new ChefFacet();
+        collectableDustFacetImplementation = new CollectableDustFacet();
         creditNftManagerFacetImplementation = new CreditNftManagerFacet();
         creditNftRedemptionCalculatorFacetImplementation = new CreditNftRedemptionCalculatorFacet();
         creditRedemptionCalculatorFacetImplementation = new CreditRedemptionCalculatorFacet();
-
+        curveDollarIncentiveFacetImplementation = new CurveDollarIncentiveFacet();
+        diamondCutFacetImplementation = new DiamondCutFacet();
+        diamondLoupeFacetImplementation = new DiamondLoupeFacet();
         dollarMintCalculatorFacetImplementation = new DollarMintCalculatorFacet();
         dollarMintExcessFacetImplementation = new DollarMintExcessFacet();
+        managerFacetImplementation = new ManagerFacet();
+        ownershipFacetImplementation = new OwnershipFacet();
+        stakingFacetImplementation = new StakingFacet();
+        stakingFormulasFacetImplementation = new StakingFormulasFacet();
+        twapOracleDollar3PoolFacetImplementation = new TWAPOracleDollar3poolFacet();
+        ubiquityPoolFacetImplementation = new UbiquityPoolFacet();
 
+        // prepare diamond init args
         diamondInit = new DiamondInit();
         facetNames = [
-            "DiamondCutFacet",
-            "DiamondLoupeFacet",
-            "OwnershipFacet",
-            "ManagerFacet",
             "AccessControlFacet",
-            "TWAPOracleDollar3poolFacet",
-            "CollectableDustFacet",
+            "BondingCurveFacet",
             "ChefFacet",
-            "StakingFacet",
-            "UbiquityPoolFacet",
-            "StakingFormulasFacet",
-            "CurveDollarIncentiveFacet",
+            "CollectableDustFacet",
             "CreditNftManagerFacet",
             "CreditNftRedemptionCalculatorFacet",
             "CreditRedemptionCalculatorFacet",
+            "CurveDollarIncentiveFacet",
+            "DiamondCutFacet",
+            "DiamondLoupeFacet",
             "DollarMintCalculatorFacet",
             "DollarMintExcessFacet",
-            "BondingCurveFacet"
+            "ManagerFacet",
+            "OwnershipFacet",
+            "StakingFacet",
+            "StakingFormulasFacet",
+            "TWAPOracleDollar3poolFacet",
+            "UbiquityPoolFacet"
         ];
-
         DiamondInit.Args memory initArgs = DiamondInit.Args({
             admin: admin,
             tos: new address[](0),
@@ -629,87 +627,40 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         cuts[0] = (
             FacetCut({
-                facetAddress: address(diamondCutFacetImplementation),
-                action: FacetCutAction.Add,
-                functionSelectors: selectorsOfDiamondCutFacet
-            })
-        );
-
-        cuts[1] = (
-            FacetCut({
-                facetAddress: address(diamondLoupeFacetImplementation),
-                action: FacetCutAction.Add,
-                functionSelectors: selectorsOfDiamondLoupeFacet
-            })
-        );
-
-        cuts[2] = (
-            FacetCut({
-                facetAddress: address(ownershipFacetImplementation),
-                action: FacetCutAction.Add,
-                functionSelectors: selectorsOfOwnershipFacet
-            })
-        );
-
-        cuts[3] = (
-            FacetCut({
-                facetAddress: address(managerFacetImplementation),
-                action: FacetCutAction.Add,
-                functionSelectors: selectorsOfManagerFacet
-            })
-        );
-
-        cuts[4] = (
-            FacetCut({
                 facetAddress: address(accessControlFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfAccessControlFacet
             })
         );
-        cuts[5] = (
+        cuts[1] = (
             FacetCut({
-                facetAddress: address(twapOracleDollar3PoolFacetImplementation),
+                facetAddress: address(bondingCurveFacetImplementation),
                 action: FacetCutAction.Add,
-                functionSelectors: selectorsOfTWAPOracleDollar3poolFacet
+                functionSelectors: selectorsOfBondingCurveFacet
             })
         );
-
-        cuts[6] = (
-            FacetCut({
-                facetAddress: address(collectableDustFacetImplementation),
-                action: FacetCutAction.Add,
-                functionSelectors: selectorsOfCollectableDustFacet
-            })
-        );
-        cuts[7] = (
+        cuts[2] = (
             FacetCut({
                 facetAddress: address(chefFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfChefFacet
             })
         );
-        cuts[8] = (
+        cuts[3] = (
             FacetCut({
-                facetAddress: address(stakingFacetImplementation),
+                facetAddress: address(collectableDustFacetImplementation),
                 action: FacetCutAction.Add,
-                functionSelectors: selectorsOfStakingFacet
+                functionSelectors: selectorsOfCollectableDustFacet
             })
         );
-        cuts[9] = (
-            FacetCut({
-                facetAddress: address(stakingFormulasFacetImplementation),
-                action: FacetCutAction.Add,
-                functionSelectors: selectorsOfStakingFormulasFacet
-            })
-        );
-        cuts[10] = (
+        cuts[4] = (
             FacetCut({
                 facetAddress: address(creditNftManagerFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfCreditNftManagerFacet
             })
         );
-        cuts[11] = (
+        cuts[5] = (
             FacetCut({
                 facetAddress: address(
                     creditNftRedemptionCalculatorFacetImplementation
@@ -718,7 +669,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
                 functionSelectors: selectorsOfCreditNftRedemptionCalculatorFacet
             })
         );
-        cuts[12] = (
+        cuts[6] = (
             FacetCut({
                 facetAddress: address(
                     creditRedemptionCalculatorFacetImplementation
@@ -727,32 +678,74 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
                 functionSelectors: selectorsOfCreditRedemptionCalculatorFacet
             })
         );
-        cuts[13] = (
+        cuts[7] = (
+            FacetCut({
+                facetAddress: address(curveDollarIncentiveFacetImplementation),
+                action: FacetCutAction.Add,
+                functionSelectors: selectorsOfCurveDollarIncentiveFacet
+            })
+        );
+        cuts[8] = (
+            FacetCut({
+                facetAddress: address(diamondCutFacetImplementation),
+                action: FacetCutAction.Add,
+                functionSelectors: selectorsOfDiamondCutFacet
+            })
+        );
+        cuts[9] = (
+            FacetCut({
+                facetAddress: address(diamondLoupeFacetImplementation),
+                action: FacetCutAction.Add,
+                functionSelectors: selectorsOfDiamondLoupeFacet
+            })
+        );
+        cuts[10] = (
             FacetCut({
                 facetAddress: address(dollarMintCalculatorFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfDollarMintCalculatorFacet
             })
         );
-        cuts[14] = (
+        cuts[11] = (
             FacetCut({
                 facetAddress: address(dollarMintExcessFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfDollarMintExcessFacet
             })
         );
+        cuts[12] = (
+            FacetCut({
+                facetAddress: address(managerFacetImplementation),
+                action: FacetCutAction.Add,
+                functionSelectors: selectorsOfManagerFacet
+            })
+        );
+        cuts[13] = (
+            FacetCut({
+                facetAddress: address(ownershipFacetImplementation),
+                action: FacetCutAction.Add,
+                functionSelectors: selectorsOfOwnershipFacet
+            })
+        );
+        cuts[14] = (
+            FacetCut({
+                facetAddress: address(stakingFacetImplementation),
+                action: FacetCutAction.Add,
+                functionSelectors: selectorsOfStakingFacet
+            })
+        );
         cuts[15] = (
             FacetCut({
-                facetAddress: address(bondingCurveFacetImplementation),
+                facetAddress: address(stakingFormulasFacetImplementation),
                 action: FacetCutAction.Add,
-                functionSelectors: selectorsOfBondingCurveFacet
+                functionSelectors: selectorsOfStakingFormulasFacet
             })
         );
         cuts[16] = (
             FacetCut({
-                facetAddress: address(curveDollarIncentiveFacetImplementation),
+                facetAddress: address(twapOracleDollar3PoolFacetImplementation),
                 action: FacetCutAction.Add,
-                functionSelectors: selectorsOfCurveDollarIncentiveFacet
+                functionSelectors: selectorsOfTWAPOracleDollar3poolFacet
             })
         );
         cuts[17] = (
@@ -762,10 +755,12 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
                 functionSelectors: selectorsOfUbiquityPoolFacet
             })
         );
+
         // deploy diamond
         vm.prank(owner);
         diamond = new Diamond(_args, cuts);
-        // initialize interfaces
+
+        // initialize diamond facets which point to the core diamond contract
         ILoupe = IDiamondLoupe(address(diamond));
         ICut = IDiamondCut(address(diamond));
         IManager = ManagerFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -58,24 +58,24 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     UbiquityPoolFacet IUbiquityPoolFacet;
 
     // diamond facet implementation instances (should not be used in tests, use only on upgrades)
-    AccessControlFacet accessControlFacet;
-    BondingCurveFacet bondingCurveFacet;
-    ChefFacet chefFacet;
-    CollectableDustFacet collectableDustFacet;
-    CreditNftManagerFacet creditNftManagerFacet;
-    CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculatorFacet;
-    CreditRedemptionCalculatorFacet creditRedemptionCalculatorFacet;
-    CurveDollarIncentiveFacet curveDollarIncentiveFacet;
+    AccessControlFacet accessControlFacetImplementation;
+    BondingCurveFacet bondingCurveFacetImplementation;
+    ChefFacet chefFacetImplementation;
+    CollectableDustFacet collectableDustFacetImplementation;
+    CreditNftManagerFacet creditNftManagerFacetImplementation;
+    CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculatorFacetImplementation;
+    CreditRedemptionCalculatorFacet creditRedemptionCalculatorFacetImplementation;
+    CurveDollarIncentiveFacet curveDollarIncentiveFacetImplementation;
     DiamondCutFacet diamondCutFacetImplementation;
-    DiamondLoupeFacet dLoupeFacet;
-    DollarMintCalculatorFacet dollarMintCalculatorFacet;
-    DollarMintExcessFacet dollarMintExcessFacet;
-    ManagerFacet managerFacet;
-    OwnershipFacet ownerFacet;
-    StakingFacet stakingFacet;
-    StakingFormulasFacet stakingFormulasFacet;
-    TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet;
-    UbiquityPoolFacet ubiquityPoolFacet;
+    DiamondLoupeFacet diamondLoupeFacetImplementation;
+    DollarMintCalculatorFacet dollarMintCalculatorFacetImplementation;
+    DollarMintExcessFacet dollarMintExcessFacetImplementation;
+    ManagerFacet managerFacetImplementation;
+    OwnershipFacet ownershipFacetImplementation;
+    StakingFacet stakingFacetImplementation;
+    StakingFormulasFacet stakingFormulasFacetImplementation;
+    TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacetImplementation;
+    UbiquityPoolFacet ubiquityPoolFacetImplementation;
 
     // facet names with addresses
     string[] facetNames;
@@ -122,15 +122,21 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         selectorsOfDiamondCutFacet.push(IDiamondCut.diamondCut.selector);
 
         // Diamond Loupe
-        selectorsOfDiamondLoupeFacet.push(IDiamondLoupe.facets.selector);
         selectorsOfDiamondLoupeFacet.push(
-            IDiamondLoupe.facetFunctionSelectors.selector
+            diamondLoupeFacetImplementation.facets.selector
         );
         selectorsOfDiamondLoupeFacet.push(
-            IDiamondLoupe.facetAddresses.selector
+            diamondLoupeFacetImplementation.facetFunctionSelectors.selector
         );
-        selectorsOfDiamondLoupeFacet.push(IDiamondLoupe.facetAddress.selector);
-        selectorsOfDiamondLoupeFacet.push(IERC165.supportsInterface.selector);
+        selectorsOfDiamondLoupeFacet.push(
+            diamondLoupeFacetImplementation.facetAddresses.selector
+        );
+        selectorsOfDiamondLoupeFacet.push(
+            diamondLoupeFacetImplementation.facetAddress.selector
+        );
+        selectorsOfDiamondLoupeFacet.push(
+            diamondLoupeFacetImplementation.supportsInterface.selector
+        );
 
         // Ownership
         selectorsOfOwnershipFacet.push(IERC173.transferOwnership.selector);
@@ -138,346 +144,446 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         // Manager selectors
         selectorsOfManagerFacet.push(
-            managerFacet.setCreditTokenAddress.selector
-        );
-        selectorsOfManagerFacet.push(managerFacet.setCreditNftAddress.selector);
-        selectorsOfManagerFacet.push(
-            managerFacet.setGovernanceTokenAddress.selector
+            managerFacetImplementation.setCreditTokenAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setDollarTokenAddress.selector
+            managerFacetImplementation.setCreditNftAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setUbiquistickAddress.selector
+            managerFacetImplementation.setGovernanceTokenAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setSushiSwapPoolAddress.selector
+            managerFacetImplementation.setDollarTokenAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setDollarMintCalculatorAddress.selector
+            managerFacetImplementation.setUbiquistickAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setExcessDollarsDistributor.selector
+            managerFacetImplementation.setSushiSwapPoolAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setMasterChefAddress.selector
-        );
-        selectorsOfManagerFacet.push(managerFacet.setFormulasAddress.selector);
-        selectorsOfManagerFacet.push(
-            managerFacet.setStakingShareAddress.selector
+            managerFacetImplementation.setDollarMintCalculatorAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setCurveDollarIncentiveAddress.selector
+            managerFacetImplementation.setExcessDollarsDistributor.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setStableSwapMetaPoolAddress.selector
+            managerFacetImplementation.setMasterChefAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setStakingContractAddress.selector
+            managerFacetImplementation.setFormulasAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.setBondingCurveAddress.selector
-        );
-        selectorsOfManagerFacet.push(managerFacet.setTreasuryAddress.selector);
-        selectorsOfManagerFacet.push(
-            managerFacet.setIncentiveToDollar.selector
+            managerFacetImplementation.setStakingShareAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.deployStableSwapPool.selector
-        );
-        selectorsOfManagerFacet.push(managerFacet.twapOracleAddress.selector);
-        selectorsOfManagerFacet.push(managerFacet.dollarTokenAddress.selector);
-        selectorsOfManagerFacet.push(managerFacet.creditTokenAddress.selector);
-        selectorsOfManagerFacet.push(managerFacet.creditNftAddress.selector);
-        selectorsOfManagerFacet.push(
-            managerFacet.curve3PoolTokenAddress.selector
+            managerFacetImplementation.setCurveDollarIncentiveAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.governanceTokenAddress.selector
+            managerFacetImplementation.setStableSwapMetaPoolAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.sushiSwapPoolAddress.selector
+            managerFacetImplementation.setStakingContractAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.creditCalculatorAddress.selector
+            managerFacetImplementation.setBondingCurveAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.creditNftCalculatorAddress.selector
+            managerFacetImplementation.setTreasuryAddress.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.dollarMintCalculatorAddress.selector
+            managerFacetImplementation.setIncentiveToDollar.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.excessDollarsDistributor.selector
-        );
-        selectorsOfManagerFacet.push(managerFacet.masterChefAddress.selector);
-        selectorsOfManagerFacet.push(managerFacet.formulasAddress.selector);
-        selectorsOfManagerFacet.push(managerFacet.stakingShareAddress.selector);
-        selectorsOfManagerFacet.push(
-            managerFacet.stableSwapMetaPoolAddress.selector
+            managerFacetImplementation.deployStableSwapPool.selector
         );
         selectorsOfManagerFacet.push(
-            managerFacet.stakingContractAddress.selector
+            managerFacetImplementation.twapOracleAddress.selector
         );
-        selectorsOfManagerFacet.push(managerFacet.treasuryAddress.selector);
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.dollarTokenAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.creditTokenAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.creditNftAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.curve3PoolTokenAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.governanceTokenAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.sushiSwapPoolAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.creditCalculatorAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.creditNftCalculatorAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.dollarMintCalculatorAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.excessDollarsDistributor.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.masterChefAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.formulasAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.stakingShareAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.stableSwapMetaPoolAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.stakingContractAddress.selector
+        );
+        selectorsOfManagerFacet.push(
+            managerFacetImplementation.treasuryAddress.selector
+        );
 
         // Access Control
         selectorsOfAccessControlFacet.push(
-            accessControlFacet.grantRole.selector
-        );
-        selectorsOfAccessControlFacet.push(accessControlFacet.hasRole.selector);
-        selectorsOfAccessControlFacet.push(
-            accessControlFacet.renounceRole.selector
+            accessControlFacetImplementation.grantRole.selector
         );
         selectorsOfAccessControlFacet.push(
-            accessControlFacet.getRoleAdmin.selector
+            accessControlFacetImplementation.hasRole.selector
         );
         selectorsOfAccessControlFacet.push(
-            accessControlFacet.revokeRole.selector
+            accessControlFacetImplementation.renounceRole.selector
         );
-        selectorsOfAccessControlFacet.push(accessControlFacet.pause.selector);
-        selectorsOfAccessControlFacet.push(accessControlFacet.unpause.selector);
-        selectorsOfAccessControlFacet.push(accessControlFacet.paused.selector);
+        selectorsOfAccessControlFacet.push(
+            accessControlFacetImplementation.getRoleAdmin.selector
+        );
+        selectorsOfAccessControlFacet.push(
+            accessControlFacetImplementation.revokeRole.selector
+        );
+        selectorsOfAccessControlFacet.push(
+            accessControlFacetImplementation.pause.selector
+        );
+        selectorsOfAccessControlFacet.push(
+            accessControlFacetImplementation.unpause.selector
+        );
+        selectorsOfAccessControlFacet.push(
+            accessControlFacetImplementation.paused.selector
+        );
 
         // TWAP Oracle
         selectorsOfTWAPOracleDollar3poolFacet.push(
-            twapOracleDollar3PoolFacet.setPool.selector
+            twapOracleDollar3PoolFacetImplementation.setPool.selector
         );
         selectorsOfTWAPOracleDollar3poolFacet.push(
-            twapOracleDollar3PoolFacet.update.selector
+            twapOracleDollar3PoolFacetImplementation.update.selector
         );
         selectorsOfTWAPOracleDollar3poolFacet.push(
-            twapOracleDollar3PoolFacet.consult.selector
+            twapOracleDollar3PoolFacetImplementation.consult.selector
         );
 
         // Collectable Dust
         selectorsOfCollectableDustFacet.push(
-            collectableDustFacet.addProtocolToken.selector
+            collectableDustFacetImplementation.addProtocolToken.selector
         );
         selectorsOfCollectableDustFacet.push(
-            collectableDustFacet.removeProtocolToken.selector
+            collectableDustFacetImplementation.removeProtocolToken.selector
         );
         selectorsOfCollectableDustFacet.push(
-            collectableDustFacet.sendDust.selector
+            collectableDustFacetImplementation.sendDust.selector
         );
         // Chef
-        selectorsOfChefFacet.push(chefFacet.setGovernancePerBlock.selector);
-        selectorsOfChefFacet.push(chefFacet.governancePerBlock.selector);
-        selectorsOfChefFacet.push(chefFacet.governanceDivider.selector);
         selectorsOfChefFacet.push(
-            chefFacet.minPriceDiffToUpdateMultiplier.selector
+            chefFacetImplementation.setGovernancePerBlock.selector
         );
         selectorsOfChefFacet.push(
-            chefFacet.setGovernanceShareForTreasury.selector
+            chefFacetImplementation.governancePerBlock.selector
         );
         selectorsOfChefFacet.push(
-            chefFacet.setMinPriceDiffToUpdateMultiplier.selector
+            chefFacetImplementation.governanceDivider.selector
         );
-        selectorsOfChefFacet.push(chefFacet.getRewards.selector);
-        selectorsOfChefFacet.push(chefFacet.pendingGovernance.selector);
-        selectorsOfChefFacet.push(chefFacet.getStakingShareInfo.selector);
-        selectorsOfChefFacet.push(chefFacet.totalShares.selector);
-        selectorsOfChefFacet.push(chefFacet.pool.selector);
+        selectorsOfChefFacet.push(
+            chefFacetImplementation.minPriceDiffToUpdateMultiplier.selector
+        );
+        selectorsOfChefFacet.push(
+            chefFacetImplementation.setGovernanceShareForTreasury.selector
+        );
+        selectorsOfChefFacet.push(
+            chefFacetImplementation.setMinPriceDiffToUpdateMultiplier.selector
+        );
+        selectorsOfChefFacet.push(chefFacetImplementation.getRewards.selector);
+        selectorsOfChefFacet.push(
+            chefFacetImplementation.pendingGovernance.selector
+        );
+        selectorsOfChefFacet.push(
+            chefFacetImplementation.getStakingShareInfo.selector
+        );
+        selectorsOfChefFacet.push(chefFacetImplementation.totalShares.selector);
+        selectorsOfChefFacet.push(chefFacetImplementation.pool.selector);
 
         // Staking
-        selectorsOfStakingFacet.push(stakingFacet.dollarPriceReset.selector);
-        selectorsOfStakingFacet.push(stakingFacet.crvPriceReset.selector);
         selectorsOfStakingFacet.push(
-            stakingFacet.setStakingDiscountMultiplier.selector
+            stakingFacetImplementation.dollarPriceReset.selector
         );
         selectorsOfStakingFacet.push(
-            stakingFacet.stakingDiscountMultiplier.selector
+            stakingFacetImplementation.crvPriceReset.selector
         );
         selectorsOfStakingFacet.push(
-            stakingFacet.setBlockCountInAWeek.selector
+            stakingFacetImplementation.setStakingDiscountMultiplier.selector
         );
-        selectorsOfStakingFacet.push(stakingFacet.blockCountInAWeek.selector);
-        selectorsOfStakingFacet.push(stakingFacet.deposit.selector);
-        selectorsOfStakingFacet.push(stakingFacet.addLiquidity.selector);
-        selectorsOfStakingFacet.push(stakingFacet.removeLiquidity.selector);
-        selectorsOfStakingFacet.push(stakingFacet.pendingLpRewards.selector);
-        selectorsOfStakingFacet.push(stakingFacet.lpRewardForShares.selector);
-        selectorsOfStakingFacet.push(stakingFacet.currentShareValue.selector);
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.stakingDiscountMultiplier.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.setBlockCountInAWeek.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.blockCountInAWeek.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.deposit.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.addLiquidity.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.removeLiquidity.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.pendingLpRewards.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.lpRewardForShares.selector
+        );
+        selectorsOfStakingFacet.push(
+            stakingFacetImplementation.currentShareValue.selector
+        );
 
         // UbiquityPool
         selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.mintDollar.selector
+            ubiquityPoolFacetImplementation.mintDollar.selector
         );
         selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.redeemDollar.selector
+            ubiquityPoolFacetImplementation.redeemDollar.selector
         );
         selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.collectRedemption.selector
-        );
-        selectorsOfUbiquityPoolFacet.push(ubiquityPoolFacet.addToken.selector);
-        selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.setRedeemActive.selector
+            ubiquityPoolFacetImplementation.collectRedemption.selector
         );
         selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.getRedeemActive.selector
+            ubiquityPoolFacetImplementation.addToken.selector
         );
         selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.setMintActive.selector
+            ubiquityPoolFacetImplementation.setRedeemActive.selector
         );
         selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.getRedeemCollateralBalances.selector
+            ubiquityPoolFacetImplementation.getRedeemActive.selector
         );
         selectorsOfUbiquityPoolFacet.push(
-            ubiquityPoolFacet.getMintActive.selector
+            ubiquityPoolFacetImplementation.setMintActive.selector
+        );
+        selectorsOfUbiquityPoolFacet.push(
+            ubiquityPoolFacetImplementation.getRedeemCollateralBalances.selector
+        );
+        selectorsOfUbiquityPoolFacet.push(
+            ubiquityPoolFacetImplementation.getMintActive.selector
         );
 
         // Staking Formulas
         selectorsOfStakingFormulasFacet.push(
-            stakingFormulasFacet.sharesForLP.selector
+            stakingFormulasFacetImplementation.sharesForLP.selector
         );
         selectorsOfStakingFormulasFacet.push(
-            stakingFormulasFacet.lpRewardsRemoveLiquidityNormalization.selector
+            stakingFormulasFacetImplementation
+                .lpRewardsRemoveLiquidityNormalization
+                .selector
         );
         selectorsOfStakingFormulasFacet.push(
-            stakingFormulasFacet.lpRewardsAddLiquidityNormalization.selector
+            stakingFormulasFacetImplementation
+                .lpRewardsAddLiquidityNormalization
+                .selector
         );
         selectorsOfStakingFormulasFacet.push(
-            stakingFormulasFacet.correctedAmountToWithdraw.selector
+            stakingFormulasFacetImplementation
+                .correctedAmountToWithdraw
+                .selector
         );
         selectorsOfStakingFormulasFacet.push(
-            stakingFormulasFacet.durationMultiply.selector
+            stakingFormulasFacetImplementation.durationMultiply.selector
         );
 
         // Bonding Curve
-        selectorsOfBondingCurveFacet.push(bondingCurveFacet.setParams.selector);
         selectorsOfBondingCurveFacet.push(
-            bondingCurveFacet.connectorWeight.selector
-        );
-        selectorsOfBondingCurveFacet.push(bondingCurveFacet.baseY.selector);
-        selectorsOfBondingCurveFacet.push(
-            bondingCurveFacet.poolBalance.selector
-        );
-        selectorsOfBondingCurveFacet.push(bondingCurveFacet.deposit.selector);
-        selectorsOfBondingCurveFacet.push(bondingCurveFacet.getShare.selector);
-        selectorsOfBondingCurveFacet.push(bondingCurveFacet.withdraw.selector);
-        selectorsOfBondingCurveFacet.push(
-            bondingCurveFacet.purchaseTargetAmount.selector
+            bondingCurveFacetImplementation.setParams.selector
         );
         selectorsOfBondingCurveFacet.push(
-            bondingCurveFacet.purchaseTargetAmountFromZero.selector
+            bondingCurveFacetImplementation.connectorWeight.selector
+        );
+        selectorsOfBondingCurveFacet.push(
+            bondingCurveFacetImplementation.baseY.selector
+        );
+        selectorsOfBondingCurveFacet.push(
+            bondingCurveFacetImplementation.poolBalance.selector
+        );
+        selectorsOfBondingCurveFacet.push(
+            bondingCurveFacetImplementation.deposit.selector
+        );
+        selectorsOfBondingCurveFacet.push(
+            bondingCurveFacetImplementation.getShare.selector
+        );
+        selectorsOfBondingCurveFacet.push(
+            bondingCurveFacetImplementation.withdraw.selector
+        );
+        selectorsOfBondingCurveFacet.push(
+            bondingCurveFacetImplementation.purchaseTargetAmount.selector
+        );
+        selectorsOfBondingCurveFacet.push(
+            bondingCurveFacetImplementation
+                .purchaseTargetAmountFromZero
+                .selector
         );
 
         // Curve Dollar Incentive Facet
         selectorsOfCurveDollarIncentiveFacet.push(
-            curveDollarIncentiveFacet.incentivize.selector
+            curveDollarIncentiveFacetImplementation.incentivize.selector
         );
         selectorsOfCurveDollarIncentiveFacet.push(
-            curveDollarIncentiveFacet.setExemptAddress.selector
+            curveDollarIncentiveFacetImplementation.setExemptAddress.selector
         );
         selectorsOfCurveDollarIncentiveFacet.push(
-            curveDollarIncentiveFacet.switchSellPenalty.selector
+            curveDollarIncentiveFacetImplementation.switchSellPenalty.selector
         );
         selectorsOfCurveDollarIncentiveFacet.push(
-            curveDollarIncentiveFacet.switchBuyIncentive.selector
+            curveDollarIncentiveFacetImplementation.switchBuyIncentive.selector
         );
         selectorsOfCurveDollarIncentiveFacet.push(
-            curveDollarIncentiveFacet.isExemptAddress.selector
+            curveDollarIncentiveFacetImplementation.isExemptAddress.selector
         );
         selectorsOfCurveDollarIncentiveFacet.push(
-            curveDollarIncentiveFacet.isSellPenaltyOn.selector
+            curveDollarIncentiveFacetImplementation.isSellPenaltyOn.selector
         );
         selectorsOfCurveDollarIncentiveFacet.push(
-            curveDollarIncentiveFacet.isBuyIncentiveOn.selector
+            curveDollarIncentiveFacetImplementation.isBuyIncentiveOn.selector
         );
 
         // Credit facets
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.creditNftLengthBlocks.selector
+            creditNftManagerFacetImplementation.creditNftLengthBlocks.selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.expiredCreditNftConversionRate.selector
+            creditNftManagerFacetImplementation
+                .expiredCreditNftConversionRate
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.setExpiredCreditNftConversionRate.selector
+            creditNftManagerFacetImplementation
+                .setExpiredCreditNftConversionRate
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.setCreditNftLength.selector
+            creditNftManagerFacetImplementation.setCreditNftLength.selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.exchangeDollarsForCreditNft.selector
+            creditNftManagerFacetImplementation
+                .exchangeDollarsForCreditNft
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.exchangeDollarsForCredit.selector
+            creditNftManagerFacetImplementation
+                .exchangeDollarsForCredit
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.getCreditNftReturnedForDollars.selector
+            creditNftManagerFacetImplementation
+                .getCreditNftReturnedForDollars
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.getCreditReturnedForDollars.selector
+            creditNftManagerFacetImplementation
+                .getCreditReturnedForDollars
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.onERC1155Received.selector
+            creditNftManagerFacetImplementation.onERC1155Received.selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.onERC1155BatchReceived.selector
+            creditNftManagerFacetImplementation.onERC1155BatchReceived.selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.burnExpiredCreditNftForGovernance.selector
+            creditNftManagerFacetImplementation
+                .burnExpiredCreditNftForGovernance
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.burnCreditNftForCredit.selector
+            creditNftManagerFacetImplementation.burnCreditNftForCredit.selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.burnCreditTokensForDollars.selector
+            creditNftManagerFacetImplementation
+                .burnCreditTokensForDollars
+                .selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.redeemCreditNft.selector
+            creditNftManagerFacetImplementation.redeemCreditNft.selector
         );
         selectorsOfCreditNftManagerFacet.push(
-            creditNftManagerFacet.mintClaimableDollars.selector
+            creditNftManagerFacetImplementation.mintClaimableDollars.selector
         );
 
         // Credit NFT Redemption Calculator
         selectorsOfCreditNftRedemptionCalculatorFacet.push(
-            creditNftRedemptionCalculatorFacet.getCreditNftAmount.selector
+            creditNftRedemptionCalculatorFacetImplementation
+                .getCreditNftAmount
+                .selector
         );
 
         // Credit Redemption Calculator
         selectorsOfCreditRedemptionCalculatorFacet.push(
-            (creditRedemptionCalculatorFacet.setConstant.selector)
+            (creditRedemptionCalculatorFacetImplementation.setConstant.selector)
         );
         selectorsOfCreditRedemptionCalculatorFacet.push(
-            (creditRedemptionCalculatorFacet.getConstant.selector)
+            (creditRedemptionCalculatorFacetImplementation.getConstant.selector)
         );
         selectorsOfCreditRedemptionCalculatorFacet.push(
-            (creditRedemptionCalculatorFacet.getCreditAmount.selector)
+            (
+                creditRedemptionCalculatorFacetImplementation
+                    .getCreditAmount
+                    .selector
+            )
         );
 
         // Dollar Mint Calculator
         selectorsOfDollarMintCalculatorFacet.push(
-            (dollarMintCalculatorFacet.getDollarsToMint.selector)
+            (dollarMintCalculatorFacetImplementation.getDollarsToMint.selector)
         );
         // Dollar Mint Excess
         selectorsOfDollarMintExcessFacet.push(
-            (dollarMintExcessFacet.distributeDollars.selector)
+            (dollarMintExcessFacetImplementation.distributeDollars.selector)
         );
 
         //deploy facets
         diamondCutFacetImplementation = new DiamondCutFacet();
-        dLoupeFacet = new DiamondLoupeFacet();
-        ownerFacet = new OwnershipFacet();
-        managerFacet = new ManagerFacet();
-        accessControlFacet = new AccessControlFacet();
-        twapOracleDollar3PoolFacet = new TWAPOracleDollar3poolFacet();
-        collectableDustFacet = new CollectableDustFacet();
-        chefFacet = new ChefFacet();
-        stakingFacet = new StakingFacet();
-        ubiquityPoolFacet = new UbiquityPoolFacet();
-        stakingFormulasFacet = new StakingFormulasFacet();
-        bondingCurveFacet = new BondingCurveFacet();
-        curveDollarIncentiveFacet = new CurveDollarIncentiveFacet();
+        diamondLoupeFacetImplementation = new DiamondLoupeFacet();
+        ownershipFacetImplementation = new OwnershipFacet();
+        managerFacetImplementation = new ManagerFacet();
+        accessControlFacetImplementation = new AccessControlFacet();
+        twapOracleDollar3PoolFacetImplementation = new TWAPOracleDollar3poolFacet();
+        collectableDustFacetImplementation = new CollectableDustFacet();
+        chefFacetImplementation = new ChefFacet();
+        stakingFacetImplementation = new StakingFacet();
+        ubiquityPoolFacetImplementation = new UbiquityPoolFacet();
+        stakingFormulasFacetImplementation = new StakingFormulasFacet();
+        bondingCurveFacetImplementation = new BondingCurveFacet();
+        curveDollarIncentiveFacetImplementation = new CurveDollarIncentiveFacet();
 
-        creditNftManagerFacet = new CreditNftManagerFacet();
-        creditNftRedemptionCalculatorFacet = new CreditNftRedemptionCalculatorFacet();
-        creditRedemptionCalculatorFacet = new CreditRedemptionCalculatorFacet();
+        creditNftManagerFacetImplementation = new CreditNftManagerFacet();
+        creditNftRedemptionCalculatorFacetImplementation = new CreditNftRedemptionCalculatorFacet();
+        creditRedemptionCalculatorFacetImplementation = new CreditRedemptionCalculatorFacet();
 
-        dollarMintCalculatorFacet = new DollarMintCalculatorFacet();
-        dollarMintExcessFacet = new DollarMintExcessFacet();
+        dollarMintCalculatorFacetImplementation = new DollarMintCalculatorFacet();
+        dollarMintExcessFacetImplementation = new DollarMintExcessFacet();
 
         diamondInit = new DiamondInit();
         facetNames = [
@@ -531,7 +637,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         cuts[1] = (
             FacetCut({
-                facetAddress: address(dLoupeFacet),
+                facetAddress: address(diamondLoupeFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfDiamondLoupeFacet
             })
@@ -539,7 +645,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         cuts[2] = (
             FacetCut({
-                facetAddress: address(ownerFacet),
+                facetAddress: address(ownershipFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfOwnershipFacet
             })
@@ -547,7 +653,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         cuts[3] = (
             FacetCut({
-                facetAddress: address(managerFacet),
+                facetAddress: address(managerFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfManagerFacet
             })
@@ -555,14 +661,14 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         cuts[4] = (
             FacetCut({
-                facetAddress: address(accessControlFacet),
+                facetAddress: address(accessControlFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfAccessControlFacet
             })
         );
         cuts[5] = (
             FacetCut({
-                facetAddress: address(twapOracleDollar3PoolFacet),
+                facetAddress: address(twapOracleDollar3PoolFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfTWAPOracleDollar3poolFacet
             })
@@ -570,84 +676,88 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         cuts[6] = (
             FacetCut({
-                facetAddress: address(collectableDustFacet),
+                facetAddress: address(collectableDustFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfCollectableDustFacet
             })
         );
         cuts[7] = (
             FacetCut({
-                facetAddress: address(chefFacet),
+                facetAddress: address(chefFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfChefFacet
             })
         );
         cuts[8] = (
             FacetCut({
-                facetAddress: address(stakingFacet),
+                facetAddress: address(stakingFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfStakingFacet
             })
         );
         cuts[9] = (
             FacetCut({
-                facetAddress: address(stakingFormulasFacet),
+                facetAddress: address(stakingFormulasFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfStakingFormulasFacet
             })
         );
         cuts[10] = (
             FacetCut({
-                facetAddress: address(creditNftManagerFacet),
+                facetAddress: address(creditNftManagerFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfCreditNftManagerFacet
             })
         );
         cuts[11] = (
             FacetCut({
-                facetAddress: address(creditNftRedemptionCalculatorFacet),
+                facetAddress: address(
+                    creditNftRedemptionCalculatorFacetImplementation
+                ),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfCreditNftRedemptionCalculatorFacet
             })
         );
         cuts[12] = (
             FacetCut({
-                facetAddress: address(creditRedemptionCalculatorFacet),
+                facetAddress: address(
+                    creditRedemptionCalculatorFacetImplementation
+                ),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfCreditRedemptionCalculatorFacet
             })
         );
         cuts[13] = (
             FacetCut({
-                facetAddress: address(dollarMintCalculatorFacet),
+                facetAddress: address(dollarMintCalculatorFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfDollarMintCalculatorFacet
             })
         );
         cuts[14] = (
             FacetCut({
-                facetAddress: address(dollarMintExcessFacet),
+                facetAddress: address(dollarMintExcessFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfDollarMintExcessFacet
             })
         );
         cuts[15] = (
             FacetCut({
-                facetAddress: address(bondingCurveFacet),
+                facetAddress: address(bondingCurveFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfBondingCurveFacet
             })
         );
         cuts[16] = (
             FacetCut({
-                facetAddress: address(curveDollarIncentiveFacet),
+                facetAddress: address(curveDollarIncentiveFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfCurveDollarIncentiveFacet
             })
         );
         cuts[17] = (
             FacetCut({
-                facetAddress: address(ubiquityPoolFacet),
+                facetAddress: address(ubiquityPoolFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfUbiquityPoolFacet
             })

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -54,7 +54,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     OwnershipFacet IOwnershipFacet;
     StakingFacet IStakingFacet;
     StakingFormulasFacet IStakingFormulasFacet;
-    TWAPOracleDollar3poolFacet ITWAPOracleDollar3pool;
+    TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet;
     UbiquityPoolFacet ubiquityPoolFacet;
 
     // diamond facet implementation instances (should not be used in tests, use only on upgrades)
@@ -783,7 +783,9 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IOwnershipFacet = OwnershipFacet(address(diamond));
         IStakingFacet = StakingFacet(address(diamond));
         IStakingFormulasFacet = StakingFormulasFacet(address(diamond));
-        ITWAPOracleDollar3pool = TWAPOracleDollar3poolFacet(address(diamond));
+        twapOracleDollar3PoolFacet = TWAPOracleDollar3poolFacet(
+            address(diamond)
+        );
         ubiquityPoolFacet = UbiquityPoolFacet(address(diamond));
 
         // get all addresses

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -52,7 +52,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     DollarMintExcessFacet IDollarMintExcessFacet;
     ManagerFacet IManager;
     OwnershipFacet IOwnershipFacet;
-    StakingFacet IStakingFacet;
+    StakingFacet stakingFacet;
     StakingFormulasFacet stakingFormulasFacet;
     TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet;
     UbiquityPoolFacet ubiquityPoolFacet;
@@ -781,7 +781,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IDollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
         IManager = ManagerFacet(address(diamond));
         IOwnershipFacet = OwnershipFacet(address(diamond));
-        IStakingFacet = StakingFacet(address(diamond));
+        stakingFacet = StakingFacet(address(diamond));
         stakingFormulasFacet = StakingFormulasFacet(address(diamond));
         twapOracleDollar3PoolFacet = TWAPOracleDollar3poolFacet(
             address(diamond)

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -29,7 +29,7 @@ import {ERC1155Ubiquity} from "../../src/dollar/core/ERC1155Ubiquity.sol";
 import {BondingCurveFacet} from "../../src/dollar/facets/BondingCurveFacet.sol";
 import "../../src/dollar/libraries/Constants.sol";
 
-abstract contract DiamondSetup is DiamondTestHelper {
+abstract contract DiamondTestSetup is DiamondTestHelper {
     // contract types of facets to be deployed
     Diamond diamond;
     DiamondCutFacet dCutFacet;

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -42,7 +42,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     BondingCurveFacet IBondingCurveFacet;
     ChefFacet IChefFacet;
     CollectableDustFacet ICollectableDustFacet;
-    CreditNftManagerFacet ICreditNftManagerFacet;
+    CreditNftManagerFacet creditNftManagerFacet;
     CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculationFacet;
     CreditRedemptionCalculatorFacet creditRedemptionCalculationFacet;
     CurveDollarIncentiveFacet curveDollarIncentiveFacet;
@@ -765,7 +765,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IBondingCurveFacet = BondingCurveFacet(address(diamond));
         IChefFacet = ChefFacet(address(diamond));
         ICollectableDustFacet = CollectableDustFacet(address(diamond));
-        ICreditNftManagerFacet = CreditNftManagerFacet(address(diamond));
+        creditNftManagerFacet = CreditNftManagerFacet(address(diamond));
         creditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(
             address(diamond)
         );

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -53,7 +53,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     ManagerFacet IManager;
     OwnershipFacet IOwnershipFacet;
     StakingFacet IStakingFacet;
-    StakingFormulasFacet IStakingFormulasFacet;
+    StakingFormulasFacet stakingFormulasFacet;
     TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet;
     UbiquityPoolFacet ubiquityPoolFacet;
 
@@ -782,7 +782,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IManager = ManagerFacet(address(diamond));
         IOwnershipFacet = OwnershipFacet(address(diamond));
         IStakingFacet = StakingFacet(address(diamond));
-        IStakingFormulasFacet = StakingFormulasFacet(address(diamond));
+        stakingFormulasFacet = StakingFormulasFacet(address(diamond));
         twapOracleDollar3PoolFacet = TWAPOracleDollar3poolFacet(
             address(diamond)
         );

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -761,23 +761,10 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         diamond = new Diamond(_args, cuts);
 
         // initialize diamond facets which point to the core diamond contract
-        ILoupe = IDiamondLoupe(address(diamond));
-        ICut = IDiamondCut(address(diamond));
-        IManager = ManagerFacet(address(diamond));
         IAccessControl = AccessControlFacet(address(diamond));
-        ITWAPOracleDollar3pool = TWAPOracleDollar3poolFacet(address(diamond));
-
-        ICollectableDustFacet = CollectableDustFacet(address(diamond));
-        IChefFacet = ChefFacet(address(diamond));
-        IStakingFacet = StakingFacet(address(diamond));
-        IUbiquityPoolFacet = UbiquityPoolFacet(address(diamond));
-        IStakingFormulasFacet = StakingFormulasFacet(address(diamond));
         IBondingCurveFacet = BondingCurveFacet(address(diamond));
-        ICurveDollarIncentiveFacet = CurveDollarIncentiveFacet(
-            address(diamond)
-        );
-        IOwnershipFacet = OwnershipFacet(address(diamond));
-
+        IChefFacet = ChefFacet(address(diamond));
+        ICollectableDustFacet = CollectableDustFacet(address(diamond));
         ICreditNftManagerFacet = CreditNftManagerFacet(address(diamond));
         ICreditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(
             address(diamond)
@@ -785,9 +772,19 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         ICreditRedemptionCalculationFacet = CreditRedemptionCalculatorFacet(
             address(diamond)
         );
-
+        ICurveDollarIncentiveFacet = CurveDollarIncentiveFacet(
+            address(diamond)
+        );
+        ICut = IDiamondCut(address(diamond));
+        ILoupe = IDiamondLoupe(address(diamond));
         IDollarMintCalcFacet = DollarMintCalculatorFacet(address(diamond));
         IDollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
+        IManager = ManagerFacet(address(diamond));
+        IOwnershipFacet = OwnershipFacet(address(diamond));
+        IStakingFacet = StakingFacet(address(diamond));
+        IStakingFormulasFacet = StakingFormulasFacet(address(diamond));
+        ITWAPOracleDollar3pool = TWAPOracleDollar3poolFacet(address(diamond));
+        IUbiquityPoolFacet = UbiquityPoolFacet(address(diamond));
 
         // get all addresses
         facetAddressList = ILoupe.facetAddresses();

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -45,7 +45,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     CreditNftManagerFacet ICreditNftManagerFacet;
     CreditNftRedemptionCalculatorFacet ICreditNftRedemptionCalculationFacet;
     CreditRedemptionCalculatorFacet ICreditRedemptionCalculationFacet;
-    CurveDollarIncentiveFacet ICurveDollarIncentiveFacet;
+    CurveDollarIncentiveFacet curveDollarIncentiveFacet;
     DiamondCutFacet diamondCutFacet;
     DiamondLoupeFacet diamondLoupeFacet;
     DollarMintCalculatorFacet dollarMintCalculatorFacet;
@@ -772,9 +772,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         ICreditRedemptionCalculationFacet = CreditRedemptionCalculatorFacet(
             address(diamond)
         );
-        ICurveDollarIncentiveFacet = CurveDollarIncentiveFacet(
-            address(diamond)
-        );
+        curveDollarIncentiveFacet = CurveDollarIncentiveFacet(address(diamond));
         diamondCutFacet = DiamondCutFacet(address(diamond));
         diamondLoupeFacet = DiamondLoupeFacet(address(diamond));
         dollarMintCalculatorFacet = DollarMintCalculatorFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -47,7 +47,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     CreditRedemptionCalculatorFacet ICreditRedemptionCalculationFacet;
     CurveDollarIncentiveFacet ICurveDollarIncentiveFacet;
     IDiamondCut ICut;
-    IDiamondLoupe ILoupe;
+    DiamondLoupeFacet diamondLoupeFacet;
     DollarMintCalculatorFacet dollarMintCalculatorFacet;
     DollarMintExcessFacet dollarMintExcessFacet;
     ManagerFacet managerFacet;
@@ -776,7 +776,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
             address(diamond)
         );
         ICut = IDiamondCut(address(diamond));
-        ILoupe = IDiamondLoupe(address(diamond));
+        diamondLoupeFacet = DiamondLoupeFacet(address(diamond));
         dollarMintCalculatorFacet = DollarMintCalculatorFacet(address(diamond));
         dollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
         managerFacet = ManagerFacet(address(diamond));
@@ -789,7 +789,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         ubiquityPoolFacet = UbiquityPoolFacet(address(diamond));
 
         // get all addresses
-        facetAddressList = ILoupe.facetAddresses();
+        facetAddressList = diamondLoupeFacet.facetAddresses();
         vm.startPrank(admin);
         // grant diamond dollar minting and burning rights
         IAccessControl.grantRole(CURVE_DOLLAR_MANAGER_ROLE, address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -48,7 +48,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     CurveDollarIncentiveFacet ICurveDollarIncentiveFacet;
     IDiamondCut ICut;
     IDiamondLoupe ILoupe;
-    DollarMintCalculatorFacet IDollarMintCalcFacet;
+    DollarMintCalculatorFacet dollarMintCalculatorFacet;
     DollarMintExcessFacet dollarMintExcessFacet;
     ManagerFacet managerFacet;
     OwnershipFacet ownershipFacet;
@@ -777,7 +777,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         );
         ICut = IDiamondCut(address(diamond));
         ILoupe = IDiamondLoupe(address(diamond));
-        IDollarMintCalcFacet = DollarMintCalculatorFacet(address(diamond));
+        dollarMintCalculatorFacet = DollarMintCalculatorFacet(address(diamond));
         dollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
         managerFacet = ManagerFacet(address(diamond));
         ownershipFacet = OwnershipFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -39,7 +39,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
     // diamond facets (which point to the core diamond and should be used across the tests)
     AccessControlFacet IAccessControl;
-    BondingCurveFacet IBondingCurveFacet;
+    BondingCurveFacet bondingCurveFacet;
     ChefFacet chefFacet;
     CollectableDustFacet collectableDustFacet;
     CreditNftManagerFacet creditNftManagerFacet;
@@ -762,7 +762,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         // initialize diamond facets which point to the core diamond contract
         IAccessControl = AccessControlFacet(address(diamond));
-        IBondingCurveFacet = BondingCurveFacet(address(diamond));
+        bondingCurveFacet = BondingCurveFacet(address(diamond));
         chefFacet = ChefFacet(address(diamond));
         collectableDustFacet = CollectableDustFacet(address(diamond));
         creditNftManagerFacet = CreditNftManagerFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -46,7 +46,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     CreditNftRedemptionCalculatorFacet ICreditNftRedemptionCalculationFacet;
     CreditRedemptionCalculatorFacet ICreditRedemptionCalculationFacet;
     CurveDollarIncentiveFacet ICurveDollarIncentiveFacet;
-    IDiamondCut ICut;
+    DiamondCutFacet diamondCutFacet;
     DiamondLoupeFacet diamondLoupeFacet;
     DollarMintCalculatorFacet dollarMintCalculatorFacet;
     DollarMintExcessFacet dollarMintExcessFacet;
@@ -775,7 +775,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         ICurveDollarIncentiveFacet = CurveDollarIncentiveFacet(
             address(diamond)
         );
-        ICut = IDiamondCut(address(diamond));
+        diamondCutFacet = DiamondCutFacet(address(diamond));
         diamondLoupeFacet = DiamondLoupeFacet(address(diamond));
         dollarMintCalculatorFacet = DollarMintCalculatorFacet(address(diamond));
         dollarMintExcessFacet = DollarMintExcessFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -43,7 +43,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     ChefFacet IChefFacet;
     CollectableDustFacet ICollectableDustFacet;
     CreditNftManagerFacet ICreditNftManagerFacet;
-    CreditNftRedemptionCalculatorFacet ICreditNftRedemptionCalculationFacet;
+    CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculationFacet;
     CreditRedemptionCalculatorFacet creditRedemptionCalculationFacet;
     CurveDollarIncentiveFacet curveDollarIncentiveFacet;
     DiamondCutFacet diamondCutFacet;
@@ -766,7 +766,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IChefFacet = ChefFacet(address(diamond));
         ICollectableDustFacet = CollectableDustFacet(address(diamond));
         ICreditNftManagerFacet = CreditNftManagerFacet(address(diamond));
-        ICreditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(
+        creditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(
             address(diamond)
         );
         creditRedemptionCalculationFacet = CreditRedemptionCalculatorFacet(

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -51,7 +51,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     DollarMintCalculatorFacet IDollarMintCalcFacet;
     DollarMintExcessFacet IDollarMintExcessFacet;
     ManagerFacet IManager;
-    OwnershipFacet IOwnershipFacet;
+    OwnershipFacet ownershipFacet;
     StakingFacet stakingFacet;
     StakingFormulasFacet stakingFormulasFacet;
     TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet;
@@ -780,7 +780,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IDollarMintCalcFacet = DollarMintCalculatorFacet(address(diamond));
         IDollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
         IManager = ManagerFacet(address(diamond));
-        IOwnershipFacet = OwnershipFacet(address(diamond));
+        ownershipFacet = OwnershipFacet(address(diamond));
         stakingFacet = StakingFacet(address(diamond));
         stakingFormulasFacet = StakingFormulasFacet(address(diamond));
         twapOracleDollar3PoolFacet = TWAPOracleDollar3poolFacet(

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -41,7 +41,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     AccessControlFacet IAccessControl;
     BondingCurveFacet IBondingCurveFacet;
     ChefFacet IChefFacet;
-    CollectableDustFacet ICollectableDustFacet;
+    CollectableDustFacet collectableDustFacet;
     CreditNftManagerFacet creditNftManagerFacet;
     CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculationFacet;
     CreditRedemptionCalculatorFacet creditRedemptionCalculationFacet;
@@ -764,7 +764,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IAccessControl = AccessControlFacet(address(diamond));
         IBondingCurveFacet = BondingCurveFacet(address(diamond));
         IChefFacet = ChefFacet(address(diamond));
-        ICollectableDustFacet = CollectableDustFacet(address(diamond));
+        collectableDustFacet = CollectableDustFacet(address(diamond));
         creditNftManagerFacet = CreditNftManagerFacet(address(diamond));
         creditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(
             address(diamond)

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -50,7 +50,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     IDiamondLoupe ILoupe;
     DollarMintCalculatorFacet IDollarMintCalcFacet;
     DollarMintExcessFacet IDollarMintExcessFacet;
-    ManagerFacet IManager;
+    ManagerFacet managerFacet;
     OwnershipFacet ownershipFacet;
     StakingFacet stakingFacet;
     StakingFormulasFacet stakingFormulasFacet;
@@ -779,7 +779,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         ILoupe = IDiamondLoupe(address(diamond));
         IDollarMintCalcFacet = DollarMintCalculatorFacet(address(diamond));
         IDollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
-        IManager = ManagerFacet(address(diamond));
+        managerFacet = ManagerFacet(address(diamond));
         ownershipFacet = OwnershipFacet(address(diamond));
         stakingFacet = StakingFacet(address(diamond));
         stakingFormulasFacet = StakingFormulasFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -1,120 +1,117 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import "@openzeppelin/contracts/interfaces/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+import {Diamond, DiamondArgs} from "../../src/dollar/Diamond.sol";
+import {ERC1155Ubiquity} from "../../src/dollar/core/ERC1155Ubiquity.sol";
 import {IDiamondCut} from "../../src/dollar/interfaces/IDiamondCut.sol";
-import {DiamondCutFacet} from "../../src/dollar/facets/DiamondCutFacet.sol";
-import {DiamondLoupeFacet} from "../../src/dollar/facets/DiamondLoupeFacet.sol";
-import {IERC173} from "../../src/dollar/interfaces/IERC173.sol";
 import {IDiamondLoupe} from "../../src/dollar/interfaces/IDiamondLoupe.sol";
-import {OwnershipFacet} from "../../src/dollar/facets/OwnershipFacet.sol";
-import {ManagerFacet} from "../../src/dollar/facets/ManagerFacet.sol";
+import {IERC173} from "../../src/dollar/interfaces/IERC173.sol";
 import {AccessControlFacet} from "../../src/dollar/facets/AccessControlFacet.sol";
-import {UbiquityPoolFacet} from "../../src/dollar/facets/UbiquityPoolFacet.sol";
-import {TWAPOracleDollar3poolFacet} from "../../src/dollar/facets/TWAPOracleDollar3poolFacet.sol";
-import {CollectableDustFacet} from "../../src/dollar/facets/CollectableDustFacet.sol";
+import {BondingCurveFacet} from "../../src/dollar/facets/BondingCurveFacet.sol";
 import {ChefFacet} from "../../src/dollar/facets/ChefFacet.sol";
-import {StakingFacet} from "../../src/dollar/facets/StakingFacet.sol";
-import {CurveDollarIncentiveFacet} from "../../src/dollar/facets/CurveDollarIncentiveFacet.sol";
-import {StakingFormulasFacet} from "../../src/dollar/facets/StakingFormulasFacet.sol";
+import {CollectableDustFacet} from "../../src/dollar/facets/CollectableDustFacet.sol";
 import {CreditNftManagerFacet} from "../../src/dollar/facets/CreditNftManagerFacet.sol";
 import {CreditNftRedemptionCalculatorFacet} from "../../src/dollar/facets/CreditNftRedemptionCalculatorFacet.sol";
 import {CreditRedemptionCalculatorFacet} from "../../src/dollar/facets/CreditRedemptionCalculatorFacet.sol";
+import {CurveDollarIncentiveFacet} from "../../src/dollar/facets/CurveDollarIncentiveFacet.sol";
+import {DiamondCutFacet} from "../../src/dollar/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/dollar/facets/DiamondLoupeFacet.sol";
 import {DollarMintCalculatorFacet} from "../../src/dollar/facets/DollarMintCalculatorFacet.sol";
 import {DollarMintExcessFacet} from "../../src/dollar/facets/DollarMintExcessFacet.sol";
-import {Diamond, DiamondArgs} from "../../src/dollar/Diamond.sol";
+import {ManagerFacet} from "../../src/dollar/facets/ManagerFacet.sol";
+import {OwnershipFacet} from "../../src/dollar/facets/OwnershipFacet.sol";
+import {StakingFacet} from "../../src/dollar/facets/StakingFacet.sol";
+import {StakingFormulasFacet} from "../../src/dollar/facets/StakingFormulasFacet.sol";
+import {TWAPOracleDollar3poolFacet} from "../../src/dollar/facets/TWAPOracleDollar3poolFacet.sol";
+import {UbiquityPoolFacet} from "../../src/dollar/facets/UbiquityPoolFacet.sol";
 import {DiamondInit} from "../../src/dollar/upgradeInitializers/DiamondInit.sol";
 import {DiamondTestHelper} from "../helpers/DiamondTestHelper.sol";
-import {ERC1155Ubiquity} from "../../src/dollar/core/ERC1155Ubiquity.sol";
-import {BondingCurveFacet} from "../../src/dollar/facets/BondingCurveFacet.sol";
-import "../../src/dollar/libraries/Constants.sol";
+import {CREDIT_NFT_MANAGER_ROLE, CREDIT_TOKEN_BURNER_ROLE, CREDIT_TOKEN_MINTER_ROLE, CURVE_DOLLAR_MANAGER_ROLE, DOLLAR_TOKEN_BURNER_ROLE, DOLLAR_TOKEN_MINTER_ROLE, GOVERNANCE_TOKEN_BURNER_ROLE, GOVERNANCE_TOKEN_MANAGER_ROLE, GOVERNANCE_TOKEN_MINTER_ROLE, STAKING_SHARE_MINTER_ROLE} from "../../src/dollar/libraries/Constants.sol";
 
+/**
+ * @notice Deploys diamond contract with all of the facets
+ */
 abstract contract DiamondTestSetup is DiamondTestHelper {
-    // contract types of facets to be deployed
+    // diamond related contracts
     Diamond diamond;
-    DiamondCutFacet dCutFacet;
-    DiamondLoupeFacet dLoupeFacet;
-    OwnershipFacet ownerFacet;
-    ManagerFacet managerFacet;
-    DiamondInit dInit;
-    // actual implementation of facets
-    AccessControlFacet accessControlFacet;
-    TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet;
-    CollectableDustFacet collectableDustFacet;
-    ChefFacet chefFacet;
-    StakingFacet stakingFacet;
-    UbiquityPoolFacet ubiquityPoolFacet;
-    StakingFormulasFacet stakingFormulasFacet;
-    BondingCurveFacet bondingCurveFacet;
-    CurveDollarIncentiveFacet curveDollarIncentiveFacet;
+    DiamondInit diamondInit;
 
-    CreditNftManagerFacet creditNftManagerFacet;
-    CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculatorFacet;
-    CreditRedemptionCalculatorFacet creditRedemptionCalculatorFacet;
-
-    DollarMintCalculatorFacet dollarMintCalculatorFacet;
-    DollarMintExcessFacet dollarMintExcessFacet;
-
-    // interfaces with Facet ABI connected to diamond address
-    IDiamondLoupe ILoupe;
-    IDiamondCut ICut;
-    ManagerFacet IManager;
-    TWAPOracleDollar3poolFacet ITWAPOracleDollar3pool;
-
-    CollectableDustFacet ICollectableDustFacet;
-    ChefFacet IChefFacet;
-    StakingFacet IStakingFacet;
-    UbiquityPoolFacet IUbiquityPoolFacet;
-    StakingFormulasFacet IStakingFormulasFacet;
-    CurveDollarIncentiveFacet ICurveDollarIncentiveFacet;
-    OwnershipFacet IOwnershipFacet;
-
+    // diamond facets (which point to the core diamond and should be used across the tests)
     AccessControlFacet IAccessControl;
     BondingCurveFacet IBondingCurveFacet;
-
+    ChefFacet IChefFacet;
+    CollectableDustFacet ICollectableDustFacet;
     CreditNftManagerFacet ICreditNftManagerFacet;
     CreditNftRedemptionCalculatorFacet ICreditNftRedemptionCalculationFacet;
     CreditRedemptionCalculatorFacet ICreditRedemptionCalculationFacet;
-
+    CurveDollarIncentiveFacet ICurveDollarIncentiveFacet;
+    IDiamondCut ICut;
+    IDiamondLoupe ILoupe;
     DollarMintCalculatorFacet IDollarMintCalcFacet;
     DollarMintExcessFacet IDollarMintExcessFacet;
+    ManagerFacet IManager;
+    OwnershipFacet IOwnershipFacet;
+    StakingFacet IStakingFacet;
+    StakingFormulasFacet IStakingFormulasFacet;
+    TWAPOracleDollar3poolFacet ITWAPOracleDollar3pool;
+    UbiquityPoolFacet IUbiquityPoolFacet;
 
+    // diamond facet implementation instances (should not be used in tests, use only on upgrades)
+    AccessControlFacet accessControlFacet;
+    BondingCurveFacet bondingCurveFacet;
+    ChefFacet chefFacet;
+    CollectableDustFacet collectableDustFacet;
+    CreditNftManagerFacet creditNftManagerFacet;
+    CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculatorFacet;
+    CreditRedemptionCalculatorFacet creditRedemptionCalculatorFacet;
+    CurveDollarIncentiveFacet curveDollarIncentiveFacet;
+    DiamondCutFacet diamondCutFacetImplementation;
+    DiamondLoupeFacet dLoupeFacet;
+    DollarMintCalculatorFacet dollarMintCalculatorFacet;
+    DollarMintExcessFacet dollarMintExcessFacet;
+    ManagerFacet managerFacet;
+    OwnershipFacet ownerFacet;
+    StakingFacet stakingFacet;
+    StakingFormulasFacet stakingFormulasFacet;
+    TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet;
+    UbiquityPoolFacet ubiquityPoolFacet;
+
+    // facet names with addresses
     string[] facetNames;
     address[] facetAddressList;
 
+    // helper addresses
     address owner;
     address admin;
-    address tokenManager;
     address user1;
     address contract1;
     address contract2;
 
-    bytes4[] selectorsOfDiamondCutFacet;
-    bytes4[] selectorsOfDiamondLoupeFacet;
-    bytes4[] selectorsOfOwnershipFacet;
-    bytes4[] selectorsOfManagerFacet;
+    // selectors for all of the facets
     bytes4[] selectorsOfAccessControlFacet;
-    bytes4[] selectorsOfTWAPOracleDollar3poolFacet;
-    bytes4[] selectorsOfCollectableDustFacet;
-    bytes4[] selectorsOfChefFacet;
-    bytes4[] selectorsOfStakingFacet;
-    bytes4[] selectorsOfUbiquityPoolFacet;
-    bytes4[] selectorsOfStakingFormulasFacet;
     bytes4[] selectorsOfBondingCurveFacet;
-    bytes4[] selectorsOfCurveDollarIncentiveFacet;
-
+    bytes4[] selectorsOfChefFacet;
+    bytes4[] selectorsOfCollectableDustFacet;
     bytes4[] selectorsOfCreditNftManagerFacet;
     bytes4[] selectorsOfCreditNftRedemptionCalculatorFacet;
     bytes4[] selectorsOfCreditRedemptionCalculatorFacet;
-
+    bytes4[] selectorsOfCurveDollarIncentiveFacet;
+    bytes4[] selectorsOfDiamondCutFacet;
+    bytes4[] selectorsOfDiamondLoupeFacet;
     bytes4[] selectorsOfDollarMintCalculatorFacet;
     bytes4[] selectorsOfDollarMintExcessFacet;
+    bytes4[] selectorsOfManagerFacet;
+    bytes4[] selectorsOfOwnershipFacet;
+    bytes4[] selectorsOfStakingFacet;
+    bytes4[] selectorsOfStakingFormulasFacet;
+    bytes4[] selectorsOfTWAPOracleDollar3poolFacet;
+    bytes4[] selectorsOfUbiquityPoolFacet;
 
-    // deploys diamond and connects facets
+    /// @notice Deploys diamond and connects facets
     function setUp() public virtual {
         owner = generateAddress("Owner", false, 10 ether);
         admin = generateAddress("Admin", false, 10 ether);
-        tokenManager = generateAddress("TokenManager", false, 10 ether);
 
         user1 = generateAddress("User1", false, 10 ether);
         contract1 = generateAddress("Contract1", true, 10 ether);
@@ -461,7 +458,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         );
 
         //deploy facets
-        dCutFacet = new DiamondCutFacet();
+        diamondCutFacetImplementation = new DiamondCutFacet();
         dLoupeFacet = new DiamondLoupeFacet();
         ownerFacet = new OwnershipFacet();
         managerFacet = new ManagerFacet();
@@ -482,7 +479,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         dollarMintCalculatorFacet = new DollarMintCalculatorFacet();
         dollarMintExcessFacet = new DollarMintExcessFacet();
 
-        dInit = new DiamondInit();
+        diamondInit = new DiamondInit();
         facetNames = [
             "DiamondCutFacet",
             "DiamondLoupeFacet",
@@ -515,7 +512,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         // diamond arguments
         DiamondArgs memory _args = DiamondArgs({
             owner: owner,
-            init: address(dInit),
+            init: address(diamondInit),
             initCalldata: abi.encodeWithSelector(
                 DiamondInit.init.selector,
                 initArgs
@@ -526,7 +523,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
 
         cuts[0] = (
             FacetCut({
-                facetAddress: address(dCutFacet),
+                facetAddress: address(diamondCutFacetImplementation),
                 action: FacetCutAction.Add,
                 functionSelectors: selectorsOfDiamondCutFacet
             })

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -38,7 +38,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     DiamondInit diamondInit;
 
     // diamond facets (which point to the core diamond and should be used across the tests)
-    AccessControlFacet IAccessControl;
+    AccessControlFacet accessControlFacet;
     BondingCurveFacet bondingCurveFacet;
     ChefFacet chefFacet;
     CollectableDustFacet collectableDustFacet;
@@ -761,7 +761,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         diamond = new Diamond(_args, cuts);
 
         // initialize diamond facets which point to the core diamond contract
-        IAccessControl = AccessControlFacet(address(diamond));
+        accessControlFacet = AccessControlFacet(address(diamond));
         bondingCurveFacet = BondingCurveFacet(address(diamond));
         chefFacet = ChefFacet(address(diamond));
         collectableDustFacet = CollectableDustFacet(address(diamond));
@@ -790,20 +790,38 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         facetAddressList = diamondLoupeFacet.facetAddresses();
         vm.startPrank(admin);
         // grant diamond dollar minting and burning rights
-        IAccessControl.grantRole(CURVE_DOLLAR_MANAGER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
+            CURVE_DOLLAR_MANAGER_ROLE,
+            address(diamond)
+        );
         // grant diamond dollar minting and burning rights
-        IAccessControl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(diamond));
-        IAccessControl.grantRole(DOLLAR_TOKEN_BURNER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
+            DOLLAR_TOKEN_MINTER_ROLE,
+            address(diamond)
+        );
+        accessControlFacet.grantRole(
+            DOLLAR_TOKEN_BURNER_ROLE,
+            address(diamond)
+        );
         // grand diamond Credit token minting and burning rights
-        IAccessControl.grantRole(CREDIT_TOKEN_MINTER_ROLE, address(diamond));
-        IAccessControl.grantRole(CREDIT_TOKEN_BURNER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
+            CREDIT_TOKEN_MINTER_ROLE,
+            address(diamond)
+        );
+        accessControlFacet.grantRole(
+            CREDIT_TOKEN_BURNER_ROLE,
+            address(diamond)
+        );
         // grant diamond token admin rights
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MANAGER_ROLE,
             address(diamond)
         );
         // grant diamond token minter rights
-        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
+            STAKING_SHARE_MINTER_ROLE,
+            address(diamond)
+        );
         // init UUPS core contracts
         __setupUUPS(address(diamond));
         vm.stopPrank();

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -55,7 +55,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     StakingFacet IStakingFacet;
     StakingFormulasFacet IStakingFormulasFacet;
     TWAPOracleDollar3poolFacet ITWAPOracleDollar3pool;
-    UbiquityPoolFacet IUbiquityPoolFacet;
+    UbiquityPoolFacet ubiquityPoolFacet;
 
     // diamond facet implementation instances (should not be used in tests, use only on upgrades)
     AccessControlFacet accessControlFacetImplementation;
@@ -784,7 +784,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         IStakingFacet = StakingFacet(address(diamond));
         IStakingFormulasFacet = StakingFormulasFacet(address(diamond));
         ITWAPOracleDollar3pool = TWAPOracleDollar3poolFacet(address(diamond));
-        IUbiquityPoolFacet = UbiquityPoolFacet(address(diamond));
+        ubiquityPoolFacet = UbiquityPoolFacet(address(diamond));
 
         // get all addresses
         facetAddressList = ILoupe.facetAddresses();

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -49,7 +49,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     IDiamondCut ICut;
     IDiamondLoupe ILoupe;
     DollarMintCalculatorFacet IDollarMintCalcFacet;
-    DollarMintExcessFacet IDollarMintExcessFacet;
+    DollarMintExcessFacet dollarMintExcessFacet;
     ManagerFacet managerFacet;
     OwnershipFacet ownershipFacet;
     StakingFacet stakingFacet;
@@ -778,7 +778,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         ICut = IDiamondCut(address(diamond));
         ILoupe = IDiamondLoupe(address(diamond));
         IDollarMintCalcFacet = DollarMintCalculatorFacet(address(diamond));
-        IDollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
+        dollarMintExcessFacet = DollarMintExcessFacet(address(diamond));
         managerFacet = ManagerFacet(address(diamond));
         ownershipFacet = OwnershipFacet(address(diamond));
         stakingFacet = StakingFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -44,7 +44,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     CollectableDustFacet ICollectableDustFacet;
     CreditNftManagerFacet ICreditNftManagerFacet;
     CreditNftRedemptionCalculatorFacet ICreditNftRedemptionCalculationFacet;
-    CreditRedemptionCalculatorFacet ICreditRedemptionCalculationFacet;
+    CreditRedemptionCalculatorFacet creditRedemptionCalculationFacet;
     CurveDollarIncentiveFacet curveDollarIncentiveFacet;
     DiamondCutFacet diamondCutFacet;
     DiamondLoupeFacet diamondLoupeFacet;
@@ -769,7 +769,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         ICreditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(
             address(diamond)
         );
-        ICreditRedemptionCalculationFacet = CreditRedemptionCalculatorFacet(
+        creditRedemptionCalculationFacet = CreditRedemptionCalculatorFacet(
             address(diamond)
         );
         curveDollarIncentiveFacet = CurveDollarIncentiveFacet(address(diamond));

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -40,7 +40,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
     // diamond facets (which point to the core diamond and should be used across the tests)
     AccessControlFacet IAccessControl;
     BondingCurveFacet IBondingCurveFacet;
-    ChefFacet IChefFacet;
+    ChefFacet chefFacet;
     CollectableDustFacet collectableDustFacet;
     CreditNftManagerFacet creditNftManagerFacet;
     CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculationFacet;
@@ -763,7 +763,7 @@ abstract contract DiamondTestSetup is DiamondTestHelper {
         // initialize diamond facets which point to the core diamond contract
         IAccessControl = AccessControlFacet(address(diamond));
         IBondingCurveFacet = BondingCurveFacet(address(diamond));
-        IChefFacet = ChefFacet(address(diamond));
+        chefFacet = ChefFacet(address(diamond));
         collectableDustFacet = CollectableDustFacet(address(diamond));
         creditNftManagerFacet = CreditNftManagerFacet(address(diamond));
         creditNftRedemptionCalculationFacet = CreditNftRedemptionCalculatorFacet(

--- a/packages/contracts/test/diamond/ERC20UbiquityDollarTest.t.sol
+++ b/packages/contracts/test/diamond/ERC20UbiquityDollarTest.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import "./DiamondTestSetup.sol";
 import "../../src/dollar/libraries/Constants.sol";
 
-contract ERC20UbiquityDollarTest is DiamondSetup {
+contract ERC20UbiquityDollarTest is DiamondTestSetup {
     event Minting(
         address indexed mockAddr1,
         address indexed minter,

--- a/packages/contracts/test/diamond/ERC20UbiquityDollarTest.t.sol
+++ b/packages/contracts/test/diamond/ERC20UbiquityDollarTest.t.sol
@@ -169,7 +169,10 @@ contract ERC20UbiquityDollarTest is DiamondTestSetup {
         // create burner role
         address burner = makeAddr("burner");
         vm.prank(admin);
-        IAccessControl.grantRole(keccak256("DOLLAR_TOKEN_BURNER_ROLE"), burner);
+        accessControlFacet.grantRole(
+            keccak256("DOLLAR_TOKEN_BURNER_ROLE"),
+            burner
+        );
         // admin pauses contract
         vm.prank(admin);
         dollarToken.pause();
@@ -188,7 +191,10 @@ contract ERC20UbiquityDollarTest is DiamondTestSetup {
         // create burner role
         address burner = makeAddr("burner");
         vm.prank(admin);
-        IAccessControl.grantRole(keccak256("DOLLAR_TOKEN_BURNER_ROLE"), burner);
+        accessControlFacet.grantRole(
+            keccak256("DOLLAR_TOKEN_BURNER_ROLE"),
+            burner
+        );
         // burn 50 tokens for user
         vm.prank(burner);
         vm.expectEmit(true, true, true, true);
@@ -245,10 +251,10 @@ contract ERC20UbiquityDollarTest is DiamondTestSetup {
 
     function testUnpause_ShouldUnpauseContract() public {
         vm.startPrank(admin);
-        IAccessControl.pause();
-        assertTrue(IAccessControl.paused());
-        IAccessControl.unpause();
-        assertFalse(IAccessControl.paused());
+        accessControlFacet.pause();
+        assertTrue(accessControlFacet.paused());
+        accessControlFacet.unpause();
+        assertFalse(accessControlFacet.paused());
         vm.stopPrank();
     }
 

--- a/packages/contracts/test/diamond/facets/AccessControlFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/AccessControlFacet.t.sol
@@ -8,7 +8,7 @@ import {AddressUtils} from "../../../src/dollar/libraries/AddressUtils.sol";
 
 import {UintUtils} from "../../../src/dollar/libraries/UintUtils.sol";
 
-contract AccessControlFacetTest is DiamondSetup {
+contract AccessControlFacetTest is DiamondTestSetup {
     using AddressUtils for address;
     using UintUtils for uint256;
 

--- a/packages/contracts/test/diamond/facets/AccessControlFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/AccessControlFacet.t.sol
@@ -33,7 +33,10 @@ contract AccessControlFacetTest is DiamondTestSetup {
         vm.prank(admin);
         vm.expectEmit(true, true, true, true);
         emit RoleGranted(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_BURNER_ROLE,
+            mock_recipient
+        );
     }
 
     // test grantRole function should revert if sender is not admin
@@ -48,19 +51,28 @@ contract AccessControlFacetTest is DiamondTestSetup {
                 uint256(DEFAULT_ADMIN_ROLE).toHexString(32)
             )
         );
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_BURNER_ROLE,
+            mock_recipient
+        );
     }
 
     // test revokeRole function should work only for admin
     function testRevokeRole_ShouldWork() public {
         vm.prank(admin);
         emit RoleGranted(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_BURNER_ROLE,
+            mock_recipient
+        );
 
         vm.prank(admin);
         vm.expectEmit(true, true, true, true);
         emit RoleRevoked(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessControl.revokeRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        accessControlFacet.revokeRole(
+            GOVERNANCE_TOKEN_BURNER_ROLE,
+            mock_recipient
+        );
     }
 
     // test revokeRole function should revert if sender is not admin
@@ -75,7 +87,10 @@ contract AccessControlFacetTest is DiamondTestSetup {
                 uint256(DEFAULT_ADMIN_ROLE).toHexString(32)
             )
         );
-        IAccessControl.revokeRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        accessControlFacet.revokeRole(
+            GOVERNANCE_TOKEN_BURNER_ROLE,
+            mock_recipient
+        );
     }
 
     // test renounceRole function should work for grantee
@@ -83,7 +98,10 @@ contract AccessControlFacetTest is DiamondTestSetup {
         vm.prank(admin);
         vm.expectEmit(true, true, true, true);
         emit RoleGranted(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient, admin);
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_BURNER_ROLE, mock_recipient);
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_BURNER_ROLE,
+            mock_recipient
+        );
 
         vm.prank(mock_recipient);
         vm.expectEmit(true, true, true, true);
@@ -92,6 +110,6 @@ contract AccessControlFacetTest is DiamondTestSetup {
             mock_recipient,
             mock_recipient
         );
-        IAccessControl.renounceRole(GOVERNANCE_TOKEN_BURNER_ROLE);
+        accessControlFacet.renounceRole(GOVERNANCE_TOKEN_BURNER_ROLE);
     }
 }

--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -32,7 +32,7 @@ contract BondingCurveFacetTest is DiamondTestSetup {
 
         vm.startPrank(admin);
 
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );

--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -40,7 +40,7 @@ contract BondingCurveFacetTest is DiamondTestSetup {
         // deploy UbiquiStick
         UbiquiStick ubiquiStick = new UbiquiStick();
         ubiquiStick.setMinter(address(diamond));
-        IManager.setUbiquistickAddress(address(ubiquiStick));
+        managerFacet.setUbiquistickAddress(address(ubiquiStick));
 
         vm.stopPrank();
     }
@@ -137,7 +137,10 @@ contract ZeroStateBonding is BondingCurveFacetTest {
         uint256 balance = poolBalance - _amount;
 
         assertEq(IBondingCurveFacet.poolBalance(), balance);
-        assertEq(dollarToken.balanceOf(IManager.treasuryAddress()), _amount);
+        assertEq(
+            dollarToken.balanceOf(managerFacet.treasuryAddress()),
+            _amount
+        );
     }
 
     function testPurchaseTargetAmountShouldRevertIfSupplyZero() public {

--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -10,7 +10,7 @@ import {ERC1155Ubiquity} from "../../../src/dollar/core/ERC1155Ubiquity.sol";
 import {UbiquiStick} from "../../../src/ubiquistick/UbiquiStick.sol";
 import "forge-std/Test.sol";
 
-contract BondingCurveFacetTest is DiamondSetup {
+contract BondingCurveFacetTest is DiamondTestSetup {
     address treasury = address(0x3);
     address secondAccount = address(0x4);
     address thirdAccount = address(0x5);

--- a/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/BondingCurveFacet.t.sol
@@ -59,10 +59,10 @@ contract ZeroStateBonding is BondingCurveFacetTest {
         emit ParamsSet(connectorWeight, baseY);
 
         vm.prank(admin);
-        IBondingCurveFacet.setParams(connectorWeight, baseY);
+        bondingCurveFacet.setParams(connectorWeight, baseY);
 
-        assertEq(connectorWeight, IBondingCurveFacet.connectorWeight());
-        assertEq(baseY, IBondingCurveFacet.baseY());
+        assertEq(connectorWeight, bondingCurveFacet.connectorWeight());
+        assertEq(baseY, bondingCurveFacet.baseY());
     }
 
     function testSetParamsShouldRevertNotAdmin() public {
@@ -73,7 +73,7 @@ contract ZeroStateBonding is BondingCurveFacetTest {
 
         vm.expectRevert("Manager: Caller is not admin");
         vm.prank(secondAccount);
-        IBondingCurveFacet.setParams(connectorWeight, baseY);
+        bondingCurveFacet.setParams(connectorWeight, baseY);
     }
 
     function testDeposit(uint32 connectorWeight, uint256 baseY) public {
@@ -83,17 +83,17 @@ contract ZeroStateBonding is BondingCurveFacetTest {
         baseY = bound(baseY, 1, 1000000);
 
         vm.prank(admin);
-        IBondingCurveFacet.setParams(connectorWeight, baseY);
+        bondingCurveFacet.setParams(connectorWeight, baseY);
 
         uint256 initBal = dollarToken.balanceOf(secondAccount);
 
         vm.expectEmit(true, false, false, true);
         emit Deposit(secondAccount, collateralDeposited);
-        IBondingCurveFacet.deposit(collateralDeposited, secondAccount);
+        bondingCurveFacet.deposit(collateralDeposited, secondAccount);
 
         uint256 finBal = dollarToken.balanceOf(secondAccount);
 
-        uint256 tokReturned = IBondingCurveFacet.purchaseTargetAmountFromZero(
+        uint256 tokReturned = bondingCurveFacet.purchaseTargetAmountFromZero(
             collateralDeposited,
             connectorWeight,
             ACCURACY,
@@ -107,10 +107,10 @@ contract ZeroStateBonding is BondingCurveFacetTest {
             .mul(SafeMath.sub((power ** (connectorWeight)), 10 ** 18))
             .div(10 ** 18);
 
-        assertEq(collateralDeposited, IBondingCurveFacet.poolBalance());
+        assertEq(collateralDeposited, bondingCurveFacet.poolBalance());
         assertEq(collateralDeposited, finBal - initBal);
         assertEq(tokReturned, result);
-        assertEq(tokReturned, IBondingCurveFacet.getShare(secondAccount));
+        assertEq(tokReturned, bondingCurveFacet.getShare(secondAccount));
         assertEq(tokReturned, creditNft.balanceOf(secondAccount, 1));
     }
 
@@ -121,22 +121,22 @@ contract ZeroStateBonding is BondingCurveFacetTest {
         baseY = bound(baseY, 1, 1000000);
 
         vm.startPrank(admin);
-        IBondingCurveFacet.setParams(connectorWeight, baseY);
+        bondingCurveFacet.setParams(connectorWeight, baseY);
 
-        IBondingCurveFacet.deposit(collateralDeposited, secondAccount);
+        bondingCurveFacet.deposit(collateralDeposited, secondAccount);
 
         uint256 _amount = bound(baseY, 0, collateralDeposited);
 
         vm.expectEmit(true, false, false, true);
         emit Withdraw(collateralDeposited);
 
-        IBondingCurveFacet.withdraw(_amount);
+        bondingCurveFacet.withdraw(_amount);
         vm.stopPrank();
 
-        uint256 poolBalance = IBondingCurveFacet.poolBalance();
+        uint256 poolBalance = bondingCurveFacet.poolBalance();
         uint256 balance = poolBalance - _amount;
 
-        assertEq(IBondingCurveFacet.poolBalance(), balance);
+        assertEq(bondingCurveFacet.poolBalance(), balance);
         assertEq(
             dollarToken.balanceOf(managerFacet.treasuryAddress()),
             _amount
@@ -149,7 +149,7 @@ contract ZeroStateBonding is BondingCurveFacetTest {
         uint32 connectorWeight = uint32(bound(connWeight, 1, MAX_WEIGHT));
 
         vm.expectRevert("ERR_INVALID_SUPPLY");
-        IBondingCurveFacet.purchaseTargetAmount(
+        bondingCurveFacet.purchaseTargetAmount(
             collateralDeposited,
             connectorWeight,
             1,
@@ -163,7 +163,7 @@ contract ZeroStateBonding is BondingCurveFacetTest {
         uint256 poolBalance = bound(bal, 1, 1000000);
 
         vm.expectRevert("ERR_INVALID_WEIGHT");
-        IBondingCurveFacet.purchaseTargetAmount(
+        bondingCurveFacet.purchaseTargetAmount(
             collateralDeposited,
             0,
             1,
@@ -182,7 +182,7 @@ contract ZeroStateBonding is BondingCurveFacetTest {
 
         // 1. Should do nothing if tokens deposited is zero
         vm.prank(secondAccount);
-        IBondingCurveFacet.purchaseTargetAmount(
+        bondingCurveFacet.purchaseTargetAmount(
             0,
             connectorWeight,
             1,
@@ -191,7 +191,7 @@ contract ZeroStateBonding is BondingCurveFacetTest {
 
         // 2. Special case if max weight is 100%
         vm.prank(thirdAccount);
-        uint256 result = IBondingCurveFacet.purchaseTargetAmount(
+        uint256 result = bondingCurveFacet.purchaseTargetAmount(
             tokensDeposited,
             MAX_WEIGHT,
             tokenIds,

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -111,7 +111,7 @@ contract ZeroStateChef is DiamondTestSetup {
         );
         //
         metapool = IMetaPool(IManager.stableSwapMetaPoolAddress());
-        metapool.transfer(address(IStakingFacet), 100e18);
+        metapool.transfer(address(stakingFacet), 100e18);
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
         vm.prank(owner);
@@ -174,7 +174,7 @@ contract ZeroStateChef is DiamondTestSetup {
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
-        IStakingFacet.setBlockCountInAWeek(420);
+        stakingFacet.setBlockCountInAWeek(420);
 
         vm.stopPrank();
 
@@ -216,7 +216,7 @@ contract ZeroStateChefTest is ZeroStateChef {
         uint256 shares = stakingFormulasFacet.durationMultiply(
             lpAmount,
             10,
-            IStakingFacet.stakingDiscountMultiplier()
+            stakingFacet.stakingDiscountMultiplier()
         );
         uint256 id = stakingShare.totalSupply() + 1;
 
@@ -234,7 +234,7 @@ contract ZeroStateChefTest is ZeroStateChef {
 
         emit Deposit(fourthAccount, shares, id);
         vm.prank(fourthAccount);
-        IStakingFacet.deposit(lpAmount, 10);
+        stakingFacet.deposit(lpAmount, 10);
 
         (, uint256 accGovernance) = IChefFacet.pool();
         uint256[2] memory info1 = [shares, (shares * accGovernance) / 1e12];
@@ -256,14 +256,14 @@ contract DepositStateChef is ZeroStateChef {
         shares = stakingFormulasFacet.durationMultiply(
             fourthBal,
             1,
-            IStakingFacet.stakingDiscountMultiplier()
+            stakingFacet.stakingDiscountMultiplier()
         );
         vm.startPrank(admin);
         fourthID = stakingShare.totalSupply() + 1;
         vm.stopPrank();
         vm.startPrank(fourthAccount);
         metapool.approve(address(diamond), fourthBal);
-        IStakingFacet.deposit(fourthBal, 1);
+        stakingFacet.deposit(fourthBal, 1);
         assertEq(stakingShare.totalSupply(), fourthID);
         assertEq(stakingShare.balanceOf(fourthAccount, fourthID), 1);
 
@@ -300,7 +300,7 @@ contract DepositStateChefTest is DepositStateChef {
         // calculate the reward in governance token for the user based on all his shares
         uint256 userReward = (shares * governancePerShare) / 1e12;
         vm.prank(fourthAccount);
-        IStakingFacet.removeLiquidity(amount, fourthID);
+        stakingFacet.removeLiquidity(amount, fourthID);
         assertEq(preBal + userReward, governanceToken.balanceOf(fourthAccount));
     }
 

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -91,7 +91,7 @@ contract ZeroStateChef is DiamondTestSetup {
         }
 
         vm.startPrank(admin);
-        IManager.setStakingShareAddress(address(stakingShare));
+        managerFacet.setStakingShareAddress(address(stakingShare));
         stakingShare.setApprovalForAll(address(diamond), true);
         IAccessControl.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
@@ -102,7 +102,7 @@ contract ZeroStateChef is DiamondTestSetup {
         address curve3CrvBasePool = address(
             new MockMetaPool(address(diamond), address(crvToken))
         );
-        IManager.deployStableSwapPool(
+        managerFacet.deployStableSwapPool(
             address(curvePoolFactory),
             curve3CrvBasePool,
             curve3CrvToken,
@@ -110,7 +110,7 @@ contract ZeroStateChef is DiamondTestSetup {
             50000000
         );
         //
-        metapool = IMetaPool(IManager.stableSwapMetaPoolAddress());
+        metapool = IMetaPool(managerFacet.stableSwapMetaPoolAddress());
         metapool.transfer(address(stakingFacet), 100e18);
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
@@ -130,7 +130,7 @@ contract ZeroStateChef is DiamondTestSetup {
             GOVERNANCE_TOKEN_BURNER_ROLE,
             address(diamond)
         );
-        IManager.setCreditTokenAddress(address(creditToken));
+        managerFacet.setCreditTokenAddress(address(creditToken));
 
         vm.stopPrank();
 

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -213,7 +213,7 @@ contract ZeroStateChefTest is ZeroStateChef {
         uint256 LPBalance = metapool.balanceOf(fourthAccount);
         lpAmount = bound(lpAmount, 1, LPBalance);
         // lock for 10 weeks
-        uint256 shares = IStakingFormulasFacet.durationMultiply(
+        uint256 shares = stakingFormulasFacet.durationMultiply(
             lpAmount,
             10,
             IStakingFacet.stakingDiscountMultiplier()
@@ -253,7 +253,7 @@ contract DepositStateChef is ZeroStateChef {
         super.setUp();
         assertEq(IChefFacet.totalShares(), 0);
         fourthBal = metapool.balanceOf(fourthAccount);
-        shares = IStakingFormulasFacet.durationMultiply(
+        shares = stakingFormulasFacet.durationMultiply(
             fourthBal,
             1,
             IStakingFacet.stakingDiscountMultiplier()

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -62,7 +62,7 @@ contract ZeroStateChef is DiamondTestSetup {
 
         vm.startPrank(owner);
 
-        ITWAPOracleDollar3pool.setPool(metaPoolAddress, curve3CrvToken);
+        twapOracleDollar3PoolFacet.setPool(metaPoolAddress, curve3CrvToken);
 
         address[7] memory mintings = [
             admin,
@@ -115,7 +115,7 @@ contract ZeroStateChef is DiamondTestSetup {
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
         vm.prank(owner);
-        ITWAPOracleDollar3pool.setPool(address(metapool), curve3CrvToken);
+        twapOracleDollar3PoolFacet.setPool(address(metapool), curve3CrvToken);
 
         vm.startPrank(admin);
 

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -15,7 +15,7 @@ import "../../../src/dollar/libraries/Constants.sol";
 import {MockERC20} from "../../../src/dollar/mocks/MockERC20.sol";
 import {MockCurveFactory} from "../../../src/dollar/mocks/MockCurveFactory.sol";
 
-contract ZeroStateChef is DiamondSetup {
+contract ZeroStateChef is DiamondTestSetup {
     MockERC20 crvToken;
     address curve3CrvToken;
     uint256 creditNftLengthBlocks = 100;

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -93,7 +93,7 @@ contract ZeroStateChef is DiamondTestSetup {
         vm.startPrank(admin);
         managerFacet.setStakingShareAddress(address(stakingShare));
         stakingShare.setApprovalForAll(address(diamond), true);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(stakingShare)
         );
@@ -119,14 +119,14 @@ contract ZeroStateChef is DiamondTestSetup {
 
         vm.startPrank(admin);
 
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
 
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_BURNER_ROLE,
             address(diamond)
         );
@@ -170,7 +170,7 @@ contract ZeroStateChef is DiamondTestSetup {
         metapool.add_liquidity(amounts_, (dyuAD2LP * 99) / 100, fourthAccount);
 
         vm.startPrank(admin);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );

--- a/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
@@ -6,7 +6,7 @@ import "../../../src/dollar/libraries/Constants.sol";
 import "../DiamondTestSetup.sol";
 import {MockERC20} from "../../../src/dollar/mocks/MockERC20.sol";
 
-contract CollectableDustFacetTest is DiamondSetup {
+contract CollectableDustFacetTest is DiamondTestSetup {
     address mock_sender = address(0x111);
     address mock_recipient = address(0x222);
     address mock_operator = address(0x333);

--- a/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
@@ -37,14 +37,14 @@ contract CollectableDustFacetTest is DiamondTestSetup {
         vm.startPrank(admin);
         vm.expectEmit(true, true, true, true);
         emit ProtocolTokenAdded(address(diamond));
-        ICollectableDustFacet.addProtocolToken(address(diamond));
+        collectableDustFacet.addProtocolToken(address(diamond));
         // mint dollar
 
         dollarToken.mint(address(diamond), 100);
         vm.stopPrank();
         vm.prank(stakingManager);
         vm.expectRevert("collectable-dust::token-is-part-of-the-protocol");
-        ICollectableDustFacet.sendDust(mock_recipient, address(diamond), 100);
+        collectableDustFacet.sendDust(mock_recipient, address(diamond), 100);
     }
 
     // test sendDust function should work only for staking manager
@@ -53,7 +53,7 @@ contract CollectableDustFacetTest is DiamondTestSetup {
         vm.prank(stakingManager);
         vm.expectEmit(true, true, true, true);
         emit DustSent(mock_recipient, address(mockToken), 100);
-        ICollectableDustFacet.sendDust(mock_recipient, address(mockToken), 100);
+        collectableDustFacet.sendDust(mock_recipient, address(mockToken), 100);
         assertEq(mockToken.balanceOf(mock_recipient), 100);
     }
 
@@ -61,10 +61,10 @@ contract CollectableDustFacetTest is DiamondTestSetup {
     function testSendDust_ShouldWorkWhenNotPartOfTheProtocol() public {
         vm.startPrank(admin);
 
-        ICollectableDustFacet.addProtocolToken(address(diamond));
+        collectableDustFacet.addProtocolToken(address(diamond));
         vm.expectEmit(true, true, true, true);
         emit ProtocolTokenRemoved(address(diamond));
-        ICollectableDustFacet.removeProtocolToken(address(diamond));
+        collectableDustFacet.removeProtocolToken(address(diamond));
         // mint dollar
 
         dollarToken.mint(address(diamond), 100);
@@ -72,7 +72,7 @@ contract CollectableDustFacetTest is DiamondTestSetup {
         assertEq(dollarToken.balanceOf(address(diamond)), 100);
         vm.prank(stakingManager);
 
-        ICollectableDustFacet.sendDust(
+        collectableDustFacet.sendDust(
             mock_recipient,
             address(dollarToken),
             100

--- a/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CollectableDustFacet.t.sol
@@ -22,7 +22,7 @@ contract CollectableDustFacetTest is DiamondTestSetup {
 
         vm.startPrank(admin);
 
-        IAccessControl.grantRole(STAKING_MANAGER_ROLE, stakingManager);
+        accessControlFacet.grantRole(STAKING_MANAGER_ROLE, stakingManager);
 
         // deploy mock token
         mockToken = new MockERC20("Mock", "MCK", 18);

--- a/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
@@ -50,13 +50,13 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
         // set this contract as minter
         vm.startPrank(admin);
-        IAccessControl.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(this));
-        IAccessControl.grantRole(CREDIT_TOKEN_MINTER_ROLE, address(this));
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(DOLLAR_TOKEN_MINTER_ROLE, address(this));
+        accessControlFacet.grantRole(CREDIT_TOKEN_MINTER_ROLE, address(this));
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
         vm.stopPrank();
     }
 
@@ -167,7 +167,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         uint256 expiryBlockNumber = 500;
         vm.startPrank(admin);
         creditNft.mintCreditNft(mockMessageSender, 2e18, expiryBlockNumber);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             keccak256("GOVERNANCE_TOKEN_MINTER_ROLE"),
             creditNftManagerAddress
         );
@@ -203,7 +203,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.startPrank(admin);
 
         creditNft.mintCreditNft(mockMessageSender, 2e18, expiryBlockNumber);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             keccak256("GOVERNANCE_TOKEN_MINTER_ROLE"),
             creditNftManagerAddress
         );
@@ -258,8 +258,11 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
     function test_redeemCreditNftRevertsIfNotEnoughBalance() public {
         vm.startPrank(admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(this));
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_MINTER_ROLE,
+            address(this)
+        );
         vm.stopPrank();
 
         mockTwapFuncs(2e18);
@@ -274,8 +277,11 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
     function test_redeemCreditNftRevertsIfNotEnoughDollars() public {
         vm.startPrank(admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(this));
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_MINTER_ROLE,
+            address(this)
+        );
         vm.stopPrank();
 
         mockTwapFuncs(2e18);
@@ -304,8 +310,11 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
     function test_redeemCreditNftRevertsIfZeroAmountOfDollars() public {
         vm.startPrank(admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(this));
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_MINTER_ROLE,
+            address(this)
+        );
         vm.stopPrank();
 
         mockTwapFuncs(2e18);
@@ -333,8 +342,11 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
     function test_redeemCreditNftWorks() public {
         vm.startPrank(admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(this));
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_MINTER_ROLE,
+            address(this)
+        );
         vm.stopPrank();
 
         mockTwapFuncs(2e18);

--- a/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
@@ -84,26 +84,26 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
     function test_setExpiredCreditNftConversionRate() public {
         vm.expectRevert("Caller is not a Credit NFT manager");
-        ICreditNftManagerFacet.setExpiredCreditNftConversionRate(100);
+        creditNftManagerFacet.setExpiredCreditNftConversionRate(100);
 
         vm.prank(admin);
-        ICreditNftManagerFacet.setExpiredCreditNftConversionRate(100);
-        assertEq(ICreditNftManagerFacet.expiredCreditNftConversionRate(), 100);
+        creditNftManagerFacet.setExpiredCreditNftConversionRate(100);
+        assertEq(creditNftManagerFacet.expiredCreditNftConversionRate(), 100);
     }
 
     function test_setCreditNftLength() public {
         vm.expectRevert("Caller is not a Credit NFT manager");
-        ICreditNftManagerFacet.setCreditNftLength(100);
+        creditNftManagerFacet.setCreditNftLength(100);
 
         vm.prank(admin);
-        ICreditNftManagerFacet.setCreditNftLength(100);
-        assertEq(ICreditNftManagerFacet.creditNftLengthBlocks(), 100);
+        creditNftManagerFacet.setCreditNftLength(100);
+        assertEq(creditNftManagerFacet.creditNftLengthBlocks(), 100);
     }
 
     function test_exchangeDollarsForCreditNft() public {
         mockTwapFuncs(2e18);
         vm.expectRevert("Price must be below 1 to mint Credit NFT");
-        ICreditNftManagerFacet.exchangeDollarsForCreditNft(100);
+        creditNftManagerFacet.exchangeDollarsForCreditNft(100);
 
         mockTwapFuncs(5e17);
         address mockSender = address(0x123);
@@ -114,7 +114,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
         dollarToken.approve(creditNftManagerAddress, 10000e18);
 
-        uint256 expiryBlockNumber = ICreditNftManagerFacet
+        uint256 expiryBlockNumber = creditNftManagerFacet
             .exchangeDollarsForCreditNft(100);
         assertEq(expiryBlockNumber, 10000 + creditNftLengthBlocks);
     }
@@ -124,7 +124,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
     {
         mockTwapFuncs(2e18);
         vm.expectRevert("Price must be below 1 to mint Credit");
-        ICreditNftManagerFacet.exchangeDollarsForCredit(100);
+        creditNftManagerFacet.exchangeDollarsForCredit(100);
     }
 
     function test_exchangeDollarsForCreditWorks() public {
@@ -136,7 +136,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
         dollarToken.approve(creditNftManagerAddress, 10000e18);
 
-        uint256 creditAmount = ICreditNftManagerFacet.exchangeDollarsForCredit(
+        uint256 creditAmount = creditNftManagerFacet.exchangeDollarsForCredit(
             100
         );
         assertEq(creditAmount, 100);
@@ -147,7 +147,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
     {
         vm.roll(1000);
         vm.expectRevert("Credit NFT has not expired");
-        ICreditNftManagerFacet.burnExpiredCreditNftForGovernance(2000, 1e18);
+        creditNftManagerFacet.burnExpiredCreditNftForGovernance(2000, 1e18);
     }
 
     function test_burnExpiredCreditNftForGovernanceRevertsIfNotEnoughBalance()
@@ -159,7 +159,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.roll(1000);
         vm.prank(mockMessageSender);
         vm.expectRevert("User not enough Credit NFT");
-        ICreditNftManagerFacet.burnExpiredCreditNftForGovernance(500, 1e18);
+        creditNftManagerFacet.burnExpiredCreditNftForGovernance(500, 1e18);
     }
 
     function test_burnExpiredCreditNftForGovernanceWorks() public {
@@ -175,7 +175,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.roll(1000);
         vm.startPrank(mockMessageSender);
         creditNft.setApprovalForAll(address(diamond), true);
-        ICreditNftManagerFacet.burnExpiredCreditNftForGovernance(
+        creditNftManagerFacet.burnExpiredCreditNftForGovernance(
             expiryBlockNumber,
             1e18
         );
@@ -188,13 +188,13 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
     function test_burnCreditNftForCreditRevertsIfExpired() public {
         vm.warp(1000);
         vm.expectRevert("Credit NFT has expired");
-        ICreditNftManagerFacet.burnCreditNftForCredit(500, 1e18);
+        creditNftManagerFacet.burnCreditNftForCredit(500, 1e18);
     }
 
     function test_burnCreditNftForCreditRevertsIfNotEnoughBalance() public {
         vm.warp(1000);
         vm.expectRevert("User not enough Credit NFT");
-        ICreditNftManagerFacet.burnCreditNftForCredit(1001, 1e18);
+        creditNftManagerFacet.burnCreditNftForCredit(1001, 1e18);
     }
 
     function test_burnCreditNftForCreditWorks() public {
@@ -211,7 +211,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.startPrank(mockMessageSender);
         vm.warp(expiryBlockNumber - 1);
         creditNft.setApprovalForAll(address(diamond), true);
-        ICreditNftManagerFacet.burnCreditNftForCredit(expiryBlockNumber, 1e18);
+        creditNftManagerFacet.burnCreditNftForCredit(expiryBlockNumber, 1e18);
         vm.stopPrank();
         uint256 redeemBalance = creditToken.balanceOf(mockMessageSender);
         assertEq(redeemBalance, 1e18);
@@ -222,13 +222,13 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
     {
         mockTwapFuncs(5e17);
         vm.expectRevert("Price must be above 1");
-        ICreditNftManagerFacet.burnCreditTokensForDollars(100);
+        creditNftManagerFacet.burnCreditTokensForDollars(100);
     }
 
     function test_burnCreditTokensForDollarsIfNotEnoughBalance() public {
         mockTwapFuncs(2e18);
         vm.expectRevert("User doesn't have enough Credit pool tokens.");
-        ICreditNftManagerFacet.burnCreditTokensForDollars(100);
+        creditNftManagerFacet.burnCreditTokensForDollars(100);
     }
 
     function test_burnCreditTokensForDollarsWorks() public {
@@ -237,7 +237,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         address account1 = address(0x123);
         UbiquityCreditToken(creditTokenAddress).mint(account1, 100e18);
         vm.prank(account1);
-        uint256 unredeemed = ICreditNftManagerFacet.burnCreditTokensForDollars(
+        uint256 unredeemed = creditNftManagerFacet.burnCreditTokensForDollars(
             10e18
         );
         assertEq(unredeemed, 10e18 - 1e18);
@@ -246,14 +246,14 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
     function test_redeemCreditNftRevertsIfPriceLowerThan1Ether() public {
         mockTwapFuncs(5e17);
         vm.expectRevert("Price must be above 1 to redeem Credit NFT");
-        ICreditNftManagerFacet.redeemCreditNft(123123123, 100);
+        creditNftManagerFacet.redeemCreditNft(123123123, 100);
     }
 
     function test_redeemCreditNftRevertsIfCreditNftExpired() public {
         mockTwapFuncs(2e18);
         vm.roll(10000);
         vm.expectRevert("Credit NFT has expired");
-        ICreditNftManagerFacet.redeemCreditNft(5555, 100);
+        creditNftManagerFacet.redeemCreditNft(5555, 100);
     }
 
     function test_redeemCreditNftRevertsIfNotEnoughBalance() public {
@@ -269,7 +269,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.expectRevert("User not enough Credit NFT");
         vm.prank(account1);
         vm.roll(expiryBlockNumber - 1);
-        ICreditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 200);
+        creditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 200);
     }
 
     function test_redeemCreditNftRevertsIfNotEnoughDollars() public {
@@ -299,7 +299,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.prank(account1);
         vm.expectRevert("There aren't enough Dollar to redeem currently");
         vm.roll(expiryBlockNumber - 1);
-        ICreditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 99);
+        creditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 99);
     }
 
     function test_redeemCreditNftRevertsIfZeroAmountOfDollars() public {
@@ -328,7 +328,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.prank(account1);
         vm.expectRevert("There aren't any Dollar to redeem currently");
         vm.roll(expiryBlockNumber - 1);
-        ICreditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 99);
+        creditNftManagerFacet.redeemCreditNft(expiryBlockNumber, 99);
     }
 
     function test_redeemCreditNftWorks() public {
@@ -355,7 +355,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         vm.startPrank(account1);
         creditNft.setApprovalForAll(address(diamond), true);
         vm.roll(expiryBlockNumber - 1);
-        uint256 unredeemedCreditNft = ICreditNftManagerFacet.redeemCreditNft(
+        uint256 unredeemedCreditNft = creditNftManagerFacet.redeemCreditNft(
             expiryBlockNumber,
             99
         );
@@ -377,7 +377,7 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
         );
 
         uint256 beforeBalance = dollarToken.balanceOf(creditNftManagerAddress);
-        ICreditNftManagerFacet.mintClaimableDollars();
+        creditNftManagerFacet.mintClaimableDollars();
         uint256 afterBalance = dollarToken.balanceOf(creditNftManagerAddress);
         assertEq(afterBalance - beforeBalance, 50);
     }

--- a/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
@@ -12,7 +12,7 @@ import {IERC20Ubiquity} from "../../../src/dollar/interfaces/IERC20Ubiquity.sol"
 import {CreditNft} from "../../../src/dollar/core/CreditNft.sol";
 import {UbiquityCreditToken} from "../../../src/dollar/core/UbiquityCreditToken.sol";
 
-contract CreditNftManagerFacetTest is DiamondSetup {
+contract CreditNftManagerFacetTest is DiamondTestSetup {
     CreditNft _creditNft;
     address dollarManagerAddress;
     address dollarTokenAddress;

--- a/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftManagerFacet.t.sol
@@ -34,19 +34,19 @@ contract CreditNftManagerFacetTest is DiamondTestSetup {
 
         _creditNft = creditNft;
         vm.prank(admin);
-        IManager.setCreditNftAddress(address(_creditNft));
+        managerFacet.setCreditNftAddress(address(_creditNft));
 
         twapOracleAddress = address(diamond);
         dollarTokenAddress = address(dollarToken);
         creditNftManagerAddress = address(diamond);
-        creditCalculatorAddress = IManager.creditCalculatorAddress();
+        creditCalculatorAddress = managerFacet.creditCalculatorAddress();
         creditNftAddress = address(_creditNft);
-        governanceTokenAddress = IManager.governanceTokenAddress();
+        governanceTokenAddress = managerFacet.governanceTokenAddress();
         // deploy credit token
         UbiquityCreditToken _creditToken = creditToken;
         creditTokenAddress = address(_creditToken);
         vm.prank(admin);
-        IManager.setCreditTokenAddress(creditTokenAddress);
+        managerFacet.setCreditTokenAddress(creditTokenAddress);
 
         // set this contract as minter
         vm.startPrank(admin);

--- a/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
@@ -21,13 +21,13 @@ contract CreditNftRedemptionCalculatorFacetTest is DiamondTestSetup {
     function test_getCreditNftAmount_revertsIfDebtTooHigh() public {
         creditNft.mintCreditNft(user1, 100000 ether, 1000);
         vm.expectRevert("CreditNft to Dollar: DEBT_TOO_HIGH");
-        ICreditNftRedemptionCalculationFacet.getCreditNftAmount(0);
+        creditNftRedemptionCalculationFacet.getCreditNftAmount(0);
     }
 
     function test_getCreditNftAmount() public {
         creditNft.mintCreditNft(user1, 5000 ether, 10);
         assertEq(
-            ICreditNftRedemptionCalculationFacet.getCreditNftAmount(10000),
+            creditNftRedemptionCalculationFacet.getCreditNftAmount(10000),
             40000
         );
     }

--- a/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import "../DiamondTestSetup.sol";
 
-contract CreditNftRedemptionCalculatorFacetTest is DiamondSetup {
+contract CreditNftRedemptionCalculatorFacetTest is DiamondTestSetup {
     function setUp() public virtual override {
         super.setUp();
         vm.prank(admin);

--- a/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
@@ -12,7 +12,7 @@ contract CreditNftRedemptionCalculatorFacetTest is DiamondTestSetup {
         assertEq(admSupply, 10000e18);
 
         vm.startPrank(admin);
-        IManager.setCreditNftAddress(address(creditNft));
+        managerFacet.setCreditNftAddress(address(creditNft));
         IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
         IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(this));
         vm.stopPrank();

--- a/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditNftRedemptionCalculatorFacet.t.sol
@@ -13,8 +13,11 @@ contract CreditNftRedemptionCalculatorFacetTest is DiamondTestSetup {
 
         vm.startPrank(admin);
         managerFacet.setCreditNftAddress(address(creditNft));
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MINTER_ROLE, address(this));
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_MINTER_ROLE,
+            address(this)
+        );
         vm.stopPrank();
     }
 

--- a/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
@@ -15,7 +15,7 @@ contract CreditRedemptionCalculatorFacetTest is DiamondTestSetup {
         vm.startPrank(admin);
         IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
         creditNft.mintCreditNft(user1, 100, 10);
-        IManager.setCreditNftAddress(address(creditNft));
+        managerFacet.setCreditNftAddress(address(creditNft));
         vm.stopPrank();
     }
 
@@ -33,7 +33,7 @@ contract CreditRedemptionCalculatorFacetTest is DiamondTestSetup {
 
     function testGetCreditAmount_ShouldRevert_IfDebtIsTooHigh() public {
         vm.mockCall(
-            IManager.dollarTokenAddress(),
+            managerFacet.dollarTokenAddress(),
             abi.encodeWithSelector(IERC20.totalSupply.selector),
             abi.encode(1)
         );

--- a/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
@@ -13,7 +13,7 @@ contract CreditRedemptionCalculatorFacetTest is DiamondTestSetup {
         assertEq(admSupply, 10000e18);
 
         vm.startPrank(admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(this));
         creditNft.mintCreditNft(user1, 100, 10);
         managerFacet.setCreditNftAddress(address(creditNft));
         vm.stopPrank();

--- a/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
@@ -22,13 +22,13 @@ contract CreditRedemptionCalculatorFacetTest is DiamondTestSetup {
     function testSetConstant_ShouldRevert_IfCalledNotByAdmin() public {
         vm.prank(user1);
         vm.expectRevert("CreditCalc: not admin");
-        ICreditRedemptionCalculationFacet.setConstant(2 ether);
+        creditRedemptionCalculationFacet.setConstant(2 ether);
     }
 
     function testSetConstant_ShouldUpdateCoef() public {
         vm.prank(admin);
-        ICreditRedemptionCalculationFacet.setConstant(2 ether);
-        assertEq(ICreditRedemptionCalculationFacet.getConstant(), 2 ether);
+        creditRedemptionCalculationFacet.setConstant(2 ether);
+        assertEq(creditRedemptionCalculationFacet.getConstant(), 2 ether);
     }
 
     function testGetCreditAmount_ShouldRevert_IfDebtIsTooHigh() public {
@@ -38,11 +38,11 @@ contract CreditRedemptionCalculatorFacetTest is DiamondTestSetup {
             abi.encode(1)
         );
         vm.expectRevert("Credit to Dollar: DEBT_TOO_HIGH");
-        ICreditRedemptionCalculationFacet.getCreditAmount(1 ether, 10);
+        creditRedemptionCalculationFacet.getCreditAmount(1 ether, 10);
     }
 
     function testGetCreditAmount_ShouldReturnAmount() public {
-        uint256 amount = ICreditRedemptionCalculationFacet.getCreditAmount(
+        uint256 amount = creditRedemptionCalculationFacet.getCreditAmount(
             1 ether,
             10
         );

--- a/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CreditRedemptionCalculatorFacet.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import "../DiamondTestSetup.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-contract CreditRedemptionCalculatorFacetTest is DiamondSetup {
+contract CreditRedemptionCalculatorFacetTest is DiamondTestSetup {
     function setUp() public virtual override {
         super.setUp();
         vm.prank(admin);

--- a/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
@@ -11,7 +11,7 @@ import {MockTWAPOracleDollar3pool} from "../../../src/dollar/mocks/MockTWAPOracl
 import "../DiamondTestSetup.sol";
 import "forge-std/Test.sol";
 
-contract CurveDollarIncentiveTest is DiamondSetup {
+contract CurveDollarIncentiveTest is DiamondTestSetup {
     address stableSwapMetaPoolAddress = address(0x123);
     address secondAccount = address(0x4);
     address thirdAccount = address(0x5);

--- a/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
@@ -29,7 +29,7 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         twapOracleAddress = address(diamond);
 
         vm.startPrank(admin);
-        IAccessControl.grantRole(CURVE_DOLLAR_MANAGER_ROLE, managerAddr);
+        accessControlFacet.grantRole(CURVE_DOLLAR_MANAGER_ROLE, managerAddr);
         vm.stopPrank();
     }
 

--- a/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
@@ -47,7 +47,7 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
 
     function testIncentivizeShouldRevertWhenCallerNotUAD() public {
         vm.expectRevert("CurveIncentive: Caller is not Ubiquity Dollar");
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             address(0x111),
             address(0x112),
             100
@@ -57,7 +57,7 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
     function testIncentivizeShouldRevertIfSenderEqualToReceiver() public {
         vm.startPrank(managerAddr);
         vm.expectRevert("CurveIncentive: cannot send self");
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             address(0x111),
             address(0x111),
             100
@@ -75,11 +75,11 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         // 1. do nothing if the target address is included to exempt list
         uint256 init_balance = governanceToken.balanceOf(mockReceiver);
 
-        ICurveDollarIncentiveFacet.setExemptAddress(mockReceiver, true);
+        curveDollarIncentiveFacet.setExemptAddress(mockReceiver, true);
         vm.stopPrank();
 
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             stableSwapPoolAddress,
             mockReceiver,
             amountIn
@@ -91,11 +91,11 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         // 2. do nothing if buyIncentive is off
         init_balance = governanceToken.balanceOf(mockReceiver);
         vm.startPrank(admin);
-        ICurveDollarIncentiveFacet.setExemptAddress(mockReceiver, false);
+        curveDollarIncentiveFacet.setExemptAddress(mockReceiver, false);
         vm.stopPrank();
 
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             stableSwapPoolAddress,
             mockReceiver,
             100e18
@@ -108,11 +108,11 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         mockTwapFuncs(1e18);
         init_balance = governanceToken.balanceOf(mockReceiver);
         vm.startPrank(admin);
-        ICurveDollarIncentiveFacet.setExemptAddress(mockReceiver, false);
+        curveDollarIncentiveFacet.setExemptAddress(mockReceiver, false);
         vm.stopPrank();
 
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             stableSwapPoolAddress,
             mockReceiver,
             100e18
@@ -125,7 +125,7 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         init_balance = governanceToken.balanceOf(mockReceiver);
         mockTwapFuncs(5e17);
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             stableSwapPoolAddress,
             mockReceiver,
             100e18
@@ -144,10 +144,10 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         // 1. do nothing if the target address is included to exempt list
         uint256 init_balance = dollarToken.balanceOf(mockSender);
         vm.prank(admin);
-        ICurveDollarIncentiveFacet.setExemptAddress(mockSender, true);
+        curveDollarIncentiveFacet.setExemptAddress(mockSender, true);
 
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             mockSender,
             stableSwapPoolAddress,
             100e18
@@ -159,11 +159,11 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         // 2. do nothing if buyIncentive is off
         init_balance = dollarToken.balanceOf(mockSender);
         vm.startPrank(admin);
-        ICurveDollarIncentiveFacet.setExemptAddress(mockSender, false);
+        curveDollarIncentiveFacet.setExemptAddress(mockSender, false);
         vm.stopPrank();
 
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             mockSender,
             stableSwapPoolAddress,
             100e18
@@ -176,11 +176,11 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         mockTwapFuncs(1e18);
         init_balance = dollarToken.balanceOf(mockSender);
         vm.startPrank(admin);
-        ICurveDollarIncentiveFacet.setExemptAddress(mockSender, false);
+        curveDollarIncentiveFacet.setExemptAddress(mockSender, false);
         vm.stopPrank();
 
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             mockSender,
             stableSwapPoolAddress,
             100e18
@@ -196,7 +196,7 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
         mockTwapFuncs(5e17);
 
         vm.prank(managerAddr);
-        ICurveDollarIncentiveFacet.incentivize(
+        curveDollarIncentiveFacet.incentivize(
             mockSender,
             stableSwapPoolAddress,
             100e18
@@ -209,39 +209,39 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
     function testSetExemptAddress_ShouldRevertOrSet_IfAdmin() public {
         address exemptAddress = address(0x123);
         vm.expectRevert("Manager: Caller is not admin");
-        ICurveDollarIncentiveFacet.setExemptAddress(exemptAddress, true);
+        curveDollarIncentiveFacet.setExemptAddress(exemptAddress, true);
 
         assertEq(
-            ICurveDollarIncentiveFacet.isExemptAddress(exemptAddress),
+            curveDollarIncentiveFacet.isExemptAddress(exemptAddress),
             false
         );
         vm.prank(admin);
         vm.expectEmit(true, true, false, true);
         emit ExemptAddressUpdate(exemptAddress, true);
-        ICurveDollarIncentiveFacet.setExemptAddress(exemptAddress, true);
+        curveDollarIncentiveFacet.setExemptAddress(exemptAddress, true);
         assertEq(
-            ICurveDollarIncentiveFacet.isExemptAddress(exemptAddress),
+            curveDollarIncentiveFacet.isExemptAddress(exemptAddress),
             true
         );
     }
 
     function testSwitchSellPenalty_ShouldRevertOrSwitch_IfAdmin() public {
         vm.expectRevert("Manager: Caller is not admin");
-        ICurveDollarIncentiveFacet.switchSellPenalty();
+        curveDollarIncentiveFacet.switchSellPenalty();
 
-        assertEq(ICurveDollarIncentiveFacet.isSellPenaltyOn(), false);
+        assertEq(curveDollarIncentiveFacet.isSellPenaltyOn(), false);
         vm.prank(admin);
-        ICurveDollarIncentiveFacet.switchSellPenalty();
-        assertEq(ICurveDollarIncentiveFacet.isSellPenaltyOn(), true);
+        curveDollarIncentiveFacet.switchSellPenalty();
+        assertEq(curveDollarIncentiveFacet.isSellPenaltyOn(), true);
     }
 
     function testSwitchBuyIncentive_ShouldRevertOrSwitch_IfAdmin() public {
         vm.expectRevert("Manager: Caller is not admin");
-        ICurveDollarIncentiveFacet.switchBuyIncentive();
+        curveDollarIncentiveFacet.switchBuyIncentive();
 
-        assertEq(ICurveDollarIncentiveFacet.isBuyIncentiveOn(), false);
+        assertEq(curveDollarIncentiveFacet.isBuyIncentiveOn(), false);
         vm.prank(admin);
-        ICurveDollarIncentiveFacet.switchBuyIncentive();
-        assertEq(ICurveDollarIncentiveFacet.isBuyIncentiveOn(), true);
+        curveDollarIncentiveFacet.switchBuyIncentive();
+        assertEq(curveDollarIncentiveFacet.isBuyIncentiveOn(), true);
     }
 }

--- a/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/CurveDollarIncentiveFacet.t.sol
@@ -67,8 +67,9 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
     function testIncentivizeBuy() public {
         vm.startPrank(admin);
 
-        address stableSwapPoolAddress = IManager.stableSwapMetaPoolAddress();
-        IERC20 governanceToken = IERC20(IManager.governanceTokenAddress());
+        address stableSwapPoolAddress = managerFacet
+            .stableSwapMetaPoolAddress();
+        IERC20 governanceToken = IERC20(managerFacet.governanceTokenAddress());
         uint256 amountIn;
 
         // 1. do nothing if the target address is included to exempt list
@@ -135,8 +136,9 @@ contract CurveDollarIncentiveTest is DiamondTestSetup {
     }
 
     function testIncentivizeSell() public {
-        address stableSwapPoolAddress = IManager.stableSwapMetaPoolAddress();
-        address dollarAddress = IManager.dollarTokenAddress();
+        address stableSwapPoolAddress = managerFacet
+            .stableSwapMetaPoolAddress();
+        address dollarAddress = managerFacet.dollarTokenAddress();
         IERC20 dollarToken = IERC20(dollarAddress);
 
         // 1. do nothing if the target address is included to exempt list

--- a/packages/contracts/test/diamond/facets/DollarMintCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/DollarMintCalculatorFacet.t.sol
@@ -33,13 +33,13 @@ contract DollarMintCalculatorFacetTest is DiamondTestSetup {
     function test_getDollarsToMintRevertsIfPriceLowerThan1USD() public {
         mockTwapFuncs(5e17);
         vm.expectRevert("DollarMintCalculator: not > 1");
-        IDollarMintCalcFacet.getDollarsToMint();
+        dollarMintCalculatorFacet.getDollarsToMint();
     }
 
     function test_getDollarsToMintWorks() public {
         mockTwapFuncs(2e18);
         uint256 totalSupply = IERC20(dollarAddress).totalSupply();
-        uint256 amountToMint = IDollarMintCalcFacet.getDollarsToMint();
+        uint256 amountToMint = dollarMintCalculatorFacet.getDollarsToMint();
         assertEq(amountToMint, totalSupply);
     }
 }

--- a/packages/contracts/test/diamond/facets/DollarMintCalculatorFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/DollarMintCalculatorFacet.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import "../DiamondTestSetup.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-contract DollarMintCalculatorFacetTest is DiamondSetup {
+contract DollarMintCalculatorFacetTest is DiamondTestSetup {
     address dollarManagerAddress;
     address dollarAddress;
     address twapOracleAddress;

--- a/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
@@ -20,7 +20,7 @@ contract DollarMintExcessFacetTest is DiamondTestSetup {
         dollarManagerAddress = address(diamond);
         twapOracleAddress = address(diamond);
 
-        excessDollarsDistributorAddress = address(IDollarMintExcessFacet);
+        excessDollarsDistributorAddress = address(dollarMintExcessFacet);
         treasuryAddress = managerFacet.treasuryAddress();
     }
 

--- a/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
@@ -8,7 +8,7 @@ import {ManagerFacet} from "../../../src/dollar/facets/ManagerFacet.sol";
 import {DollarMintExcessFacet} from "../../../src/dollar/facets/DollarMintExcessFacet.sol";
 import "../DiamondTestSetup.sol";
 
-contract DollarMintExcessFacetTest is DiamondSetup {
+contract DollarMintExcessFacetTest is DiamondTestSetup {
     address dollarManagerAddress;
     address treasuryAddress;
     address twapOracleAddress;

--- a/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
@@ -21,7 +21,7 @@ contract DollarMintExcessFacetTest is DiamondTestSetup {
         twapOracleAddress = address(diamond);
 
         excessDollarsDistributorAddress = address(IDollarMintExcessFacet);
-        treasuryAddress = IManager.treasuryAddress();
+        treasuryAddress = managerFacet.treasuryAddress();
     }
 
     function mockSushiSwapRouter(uint256 _expected_swap_amount) public {

--- a/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
@@ -11,7 +11,7 @@ import {MockERC20} from "../../../src/dollar/mocks/MockERC20.sol";
 import {MockMetaPool} from "../../../src/dollar/mocks/MockMetaPool.sol";
 import {MockCurveFactory} from "../../../src/dollar/mocks/MockCurveFactory.sol";
 
-contract ManagerFacetTest is DiamondSetup {
+contract ManagerFacetTest is DiamondTestSetup {
     function testCanCallGeneralFunctions_ShouldSucceed() public view {
         IManager.excessDollarsDistributor(contract1);
     }

--- a/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
@@ -101,11 +101,11 @@ contract ManagerFacetTest is DiamondTestSetup {
 
     function testSetIncentiveToDollar_ShouldSucceed() public prankAs(admin) {
         assertEq(
-            IAccessControl.hasRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin),
+            accessControlFacet.hasRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin),
             true
         );
         assertEq(
-            IAccessControl.hasRole(
+            accessControlFacet.hasRole(
                 GOVERNANCE_TOKEN_MANAGER_ROLE,
                 address(diamond)
             ),
@@ -119,7 +119,7 @@ contract ManagerFacetTest is DiamondTestSetup {
         prankAs(admin)
     {
         assertEq(
-            IAccessControl.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, admin),
+            accessControlFacet.hasRole(GOVERNANCE_TOKEN_MINTER_ROLE, admin),
             true
         );
     }
@@ -157,11 +157,11 @@ contract ManagerFacetTest is DiamondTestSetup {
         }
 
         address stakingV1Address = generateAddress("stakingV1", true, 10 ether);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             stakingV1Address
         );
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_BURNER_ROLE,
             stakingV1Address
         );

--- a/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
@@ -13,90 +13,90 @@ import {MockCurveFactory} from "../../../src/dollar/mocks/MockCurveFactory.sol";
 
 contract ManagerFacetTest is DiamondTestSetup {
     function testCanCallGeneralFunctions_ShouldSucceed() public view {
-        IManager.excessDollarsDistributor(contract1);
+        managerFacet.excessDollarsDistributor(contract1);
     }
 
     function testSetTwapOracleAddress_ShouldSucceed() public prankAs(admin) {
-        assertEq(IManager.twapOracleAddress(), address(diamond));
+        assertEq(managerFacet.twapOracleAddress(), address(diamond));
     }
 
     function testSetDollarTokenAddress_ShouldSucceed() public prankAs(admin) {
-        assertEq(IManager.dollarTokenAddress(), address(dollarToken));
+        assertEq(managerFacet.dollarTokenAddress(), address(dollarToken));
     }
 
     function testSetCreditTokenAddress_ShouldSucceed() public prankAs(admin) {
-        IManager.setCreditTokenAddress(contract1);
-        assertEq(IManager.creditTokenAddress(), contract1);
+        managerFacet.setCreditTokenAddress(contract1);
+        assertEq(managerFacet.creditTokenAddress(), contract1);
     }
 
     function testSetCreditNftAddress_ShouldSucceed() public prankAs(admin) {
-        IManager.setCreditNftAddress(contract1);
-        assertEq(IManager.creditNftAddress(), contract1);
+        managerFacet.setCreditNftAddress(contract1);
+        assertEq(managerFacet.creditNftAddress(), contract1);
     }
 
     function testSetGovernanceTokenAddress_ShouldSucceed()
         public
         prankAs(admin)
     {
-        IManager.setGovernanceTokenAddress(contract1);
-        assertEq(IManager.governanceTokenAddress(), contract1);
+        managerFacet.setGovernanceTokenAddress(contract1);
+        assertEq(managerFacet.governanceTokenAddress(), contract1);
     }
 
     function testSetSushiSwapPoolAddress_ShouldSucceed() public prankAs(admin) {
-        IManager.setSushiSwapPoolAddress(contract1);
-        assertEq(IManager.sushiSwapPoolAddress(), contract1);
+        managerFacet.setSushiSwapPoolAddress(contract1);
+        assertEq(managerFacet.sushiSwapPoolAddress(), contract1);
     }
 
     function testSetDollarMintCalculatorAddress_ShouldSucceed()
         public
         prankAs(admin)
     {
-        IManager.setDollarMintCalculatorAddress(contract1);
-        assertEq(IManager.dollarMintCalculatorAddress(), contract1);
+        managerFacet.setDollarMintCalculatorAddress(contract1);
+        assertEq(managerFacet.dollarMintCalculatorAddress(), contract1);
     }
 
     function testSetExcessDollarsDistributor_ShouldSucceed()
         public
         prankAs(admin)
     {
-        IManager.setExcessDollarsDistributor(contract1, contract2);
-        assertEq(IManager.excessDollarsDistributor(contract1), contract2);
+        managerFacet.setExcessDollarsDistributor(contract1, contract2);
+        assertEq(managerFacet.excessDollarsDistributor(contract1), contract2);
     }
 
     function testSetMasterChefAddress_ShouldSucceed() public prankAs(admin) {
-        IManager.setMasterChefAddress(contract1);
-        assertEq(IManager.masterChefAddress(), contract1);
+        managerFacet.setMasterChefAddress(contract1);
+        assertEq(managerFacet.masterChefAddress(), contract1);
     }
 
     function testSetFormulasAddress_ShouldSucceed() public prankAs(admin) {
-        IManager.setFormulasAddress(contract1);
-        assertEq(IManager.formulasAddress(), contract1);
+        managerFacet.setFormulasAddress(contract1);
+        assertEq(managerFacet.formulasAddress(), contract1);
     }
 
     function testSetStakingShareAddress_ShouldSucceed() public prankAs(admin) {
-        IManager.setStakingShareAddress(contract1);
-        assertEq(IManager.stakingShareAddress(), contract1);
+        managerFacet.setStakingShareAddress(contract1);
+        assertEq(managerFacet.stakingShareAddress(), contract1);
     }
 
     function testSetStableSwapMetaPoolAddress_ShouldSucceed()
         public
         prankAs(admin)
     {
-        IManager.setStableSwapMetaPoolAddress(contract1);
-        assertEq(IManager.stableSwapMetaPoolAddress(), contract1);
+        managerFacet.setStableSwapMetaPoolAddress(contract1);
+        assertEq(managerFacet.stableSwapMetaPoolAddress(), contract1);
     }
 
     function testSetStakingContractAddress_ShouldSucceed()
         public
         prankAs(admin)
     {
-        IManager.setStakingContractAddress(contract1);
-        assertEq(IManager.stakingContractAddress(), contract1);
+        managerFacet.setStakingContractAddress(contract1);
+        assertEq(managerFacet.stakingContractAddress(), contract1);
     }
 
     function testSetTreasuryAddress_ShouldSucceed() public prankAs(admin) {
-        IManager.setTreasuryAddress(contract1);
-        assertEq(IManager.treasuryAddress(), contract1);
+        managerFacet.setTreasuryAddress(contract1);
+        assertEq(managerFacet.treasuryAddress(), contract1);
     }
 
     function testSetIncentiveToDollar_ShouldSucceed() public prankAs(admin) {
@@ -111,7 +111,7 @@ contract ManagerFacetTest is DiamondTestSetup {
             ),
             true
         );
-        IManager.setIncentiveToDollar(user1, contract1);
+        managerFacet.setIncentiveToDollar(user1, contract1);
     }
 
     function testSetMinterRoleWhenInitializing_ShouldSucceed()
@@ -128,7 +128,7 @@ contract ManagerFacetTest is DiamondTestSetup {
         public
         prankAs(admin)
     {
-        assertEq(IManager.dollarTokenAddress(), address(dollarToken));
+        assertEq(managerFacet.dollarTokenAddress(), address(dollarToken));
     }
 
     function testDeployStableSwapPool_ShouldSucceed() public {
@@ -189,7 +189,7 @@ contract ManagerFacetTest is DiamondTestSetup {
         address curve3CrvBasePool = address(
             new MockMetaPool(address(diamond), address(curve3CrvToken))
         );
-        IManager.deployStableSwapPool(
+        managerFacet.deployStableSwapPool(
             address(curvePoolFactory),
             curve3CrvBasePool,
             address(curve3CrvToken),
@@ -197,7 +197,9 @@ contract ManagerFacetTest is DiamondTestSetup {
             50000000
         );
 
-        IMetaPool metapool = IMetaPool(IManager.stableSwapMetaPoolAddress());
+        IMetaPool metapool = IMetaPool(
+            managerFacet.stableSwapMetaPoolAddress()
+        );
         address stakingV2Address = generateAddress("stakingV2", true, 10 ether);
         metapool.transfer(address(stakingV2Address), 100e18);
         vm.stopPrank();

--- a/packages/contracts/test/diamond/facets/OwnershipFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/OwnershipFacet.t.sol
@@ -8,7 +8,7 @@ import {AddressUtils} from "../../../src/dollar/libraries/AddressUtils.sol";
 
 import {UintUtils} from "../../../src/dollar/libraries/UintUtils.sol";
 
-contract OwnershipFacetTest is DiamondSetup {
+contract OwnershipFacetTest is DiamondTestSetup {
     using AddressUtils for address;
     using UintUtils for uint256;
 

--- a/packages/contracts/test/diamond/facets/OwnershipFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/OwnershipFacet.t.sol
@@ -23,26 +23,26 @@ contract OwnershipFacetTest is DiamondTestSetup {
 
     // test OwnershipFacet transferOwnership should revert if sender is not owner
     function testTransferOwnership_ShouldRevertWhenNotOwner() public {
-        assertEq(IOwnershipFacet.owner(), owner);
+        assertEq(ownershipFacet.owner(), owner);
         vm.prank(mock_sender);
         vm.expectRevert(abi.encodePacked("LibDiamond: Must be contract owner"));
-        IOwnershipFacet.transferOwnership(mock_recipient);
-        assertEq(IOwnershipFacet.owner(), owner);
+        ownershipFacet.transferOwnership(mock_recipient);
+        assertEq(ownershipFacet.owner(), owner);
     }
 
     // test OwnershipFacet transferOwnership should revert if new owner is zero address
     function testTransferOwnership_ShouldRevertWhenNewOwnerIsZeroAddress()
         public
     {
-        assertEq(IOwnershipFacet.owner(), owner);
+        assertEq(ownershipFacet.owner(), owner);
         vm.prank(owner);
         vm.expectRevert(
             abi.encodePacked(
                 "OwnershipFacet: New owner cannot be the zero address"
             )
         );
-        IOwnershipFacet.transferOwnership(address(0));
-        assertEq(IOwnershipFacet.owner(), owner);
+        ownershipFacet.transferOwnership(address(0));
+        assertEq(ownershipFacet.owner(), owner);
     }
 
     // test OwnershipFacet transferOwnership should work if new owner is not contract
@@ -52,7 +52,7 @@ contract OwnershipFacetTest is DiamondTestSetup {
         vm.prank(owner);
         vm.expectEmit(true, true, true, true);
         emit OwnershipTransferred(owner, mock_recipient);
-        IOwnershipFacet.transferOwnership(mock_recipient);
-        assertEq(IOwnershipFacet.owner(), mock_recipient);
+        ownershipFacet.transferOwnership(mock_recipient);
+        assertEq(ownershipFacet.owner(), mock_recipient);
     }
 }

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -18,7 +18,7 @@ import {MockCurveFactory} from "../../../src/dollar/mocks/MockCurveFactory.sol";
 import {MockERC20} from "../../../src/dollar/mocks/MockERC20.sol";
 import "forge-std/Test.sol";
 
-contract ZeroStateStaking is DiamondSetup {
+contract ZeroStateStaking is DiamondTestSetup {
     MockERC20 crvToken;
     uint256 creditNftLengthBlocks = 100;
     address treasury = address(0x3);

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -227,7 +227,7 @@ contract ZeroStateStakingTest is ZeroStateStaking {
             stakingMinAccount,
             stakingShare.totalSupply(),
             lpAmount,
-            IStakingFormulasFacet.durationMultiply(
+            stakingFormulasFacet.durationMultiply(
                 lpAmount,
                 lockup,
                 IStakingFacet.stakingDiscountMultiplier()
@@ -283,7 +283,7 @@ contract DepositStateStaking is ZeroStateStaking {
 
         assertEq(IChefFacet.totalShares(), 0);
         fourthBal = metapool.balanceOf(fourthAccount);
-        shares = IStakingFormulasFacet.durationMultiply(
+        shares = stakingFormulasFacet.durationMultiply(
             fourthBal,
             1,
             IStakingFacet.stakingDiscountMultiplier()

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -97,7 +97,7 @@ contract ZeroStateStaking is DiamondTestSetup {
 
         vm.startPrank(admin);
         stakingShare.setApprovalForAll(address(diamond), true);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(stakingShare)
         );
@@ -128,14 +128,14 @@ contract ZeroStateStaking is DiamondTestSetup {
 
         vm.startPrank(admin);
 
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
 
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_BURNER_ROLE,
             address(diamond)
         );
@@ -179,7 +179,7 @@ contract ZeroStateStaking is DiamondTestSetup {
         metapool.add_liquidity(amounts_, (dyuAD2LP * 99) / 100, fourthAccount);
 
         vm.startPrank(admin);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -68,7 +68,7 @@ contract ZeroStateStaking is DiamondTestSetup {
 
         vm.startPrank(owner);
 
-        ITWAPOracleDollar3pool.setPool(metaPoolAddress, address(crvToken));
+        twapOracleDollar3PoolFacet.setPool(metaPoolAddress, address(crvToken));
 
         address[7] memory mintings = [
             admin,
@@ -121,7 +121,10 @@ contract ZeroStateStaking is DiamondTestSetup {
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
         vm.prank(owner);
-        ITWAPOracleDollar3pool.setPool(address(metapool), address(crvToken));
+        twapOracleDollar3PoolFacet.setPool(
+            address(metapool),
+            address(crvToken)
+        );
 
         vm.startPrank(admin);
 

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -108,7 +108,7 @@ contract ZeroStateStaking is DiamondTestSetup {
         );
 
         //vm.prank(admin);
-        IManager.deployStableSwapPool(
+        managerFacet.deployStableSwapPool(
             address(curvePoolFactory),
             curve3CrvBasePool,
             address(crvToken),
@@ -116,7 +116,7 @@ contract ZeroStateStaking is DiamondTestSetup {
             50000000
         );
         //
-        metapool = IMetaPool(IManager.stableSwapMetaPoolAddress());
+        metapool = IMetaPool(managerFacet.stableSwapMetaPoolAddress());
         metapool.transfer(address(stakingFacet), 100e18);
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
@@ -139,7 +139,7 @@ contract ZeroStateStaking is DiamondTestSetup {
             GOVERNANCE_TOKEN_BURNER_ROLE,
             address(diamond)
         );
-        IManager.setCreditTokenAddress(address(creditToken));
+        managerFacet.setCreditTokenAddress(address(creditToken));
 
         vm.stopPrank();
 

--- a/packages/contracts/test/diamond/facets/StakingFormulasFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFormulasFacet.t.sol
@@ -5,7 +5,7 @@ import "../DiamondTestSetup.sol";
 import "abdk/ABDKMathQuad.sol";
 import {StakingShare} from "../../../src/dollar/core/StakingShare.sol";
 
-contract StakingFormulasFacetTest is DiamondSetup {
+contract StakingFormulasFacetTest is DiamondTestSetup {
     using ABDKMathQuad for uint256;
     using ABDKMathQuad for bytes16;
 

--- a/packages/contracts/test/diamond/facets/StakingFormulasFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFormulasFacet.t.sol
@@ -31,7 +31,7 @@ contract StakingFormulasFacetTest is DiamondTestSetup {
         uint256 _amount = 10;
 
         assertEq(
-            IStakingFormulasFacet.sharesForLP(_stake, _shareInfo, _amount),
+            stakingFormulasFacet.sharesForLP(_stake, _shareInfo, _amount),
             10
         );
     }
@@ -42,7 +42,7 @@ contract StakingFormulasFacetTest is DiamondTestSetup {
         uint256 _amount
     ) public {
         assertEq(
-            IStakingFormulasFacet.lpRewardsRemoveLiquidityNormalization(
+            stakingFormulasFacet.lpRewardsRemoveLiquidityNormalization(
                 _stake,
                 _shareInfo,
                 _amount
@@ -57,7 +57,7 @@ contract StakingFormulasFacetTest is DiamondTestSetup {
         uint256 _amount
     ) public {
         assertEq(
-            IStakingFormulasFacet.lpRewardsAddLiquidityNormalization(
+            stakingFormulasFacet.lpRewardsAddLiquidityNormalization(
                 _stake,
                 _shareInfo,
                 _amount
@@ -71,7 +71,7 @@ contract StakingFormulasFacetTest is DiamondTestSetup {
         uint256 _stakingLpBalance = 20000;
         uint256 _amount = 100;
         assertEq(
-            IStakingFormulasFacet.correctedAmountToWithdraw(
+            stakingFormulasFacet.correctedAmountToWithdraw(
                 _totalLpDeposited,
                 _stakingLpBalance,
                 _amount
@@ -85,7 +85,7 @@ contract StakingFormulasFacetTest is DiamondTestSetup {
         uint256 _stakingLpBalance = 5000;
         uint256 _amount = 100;
         assertEq(
-            IStakingFormulasFacet.correctedAmountToWithdraw(
+            stakingFormulasFacet.correctedAmountToWithdraw(
                 _totalLpDeposited,
                 _stakingLpBalance,
                 _amount
@@ -95,7 +95,7 @@ contract StakingFormulasFacetTest is DiamondTestSetup {
     }
 
     function testDurationMultiply_ShouldReturnAmount() public {
-        uint256 amount = IStakingFormulasFacet.durationMultiply(
+        uint256 amount = stakingFormulasFacet.durationMultiply(
             100 ether,
             1,
             1000000 gwei

--- a/packages/contracts/test/diamond/facets/TWAPOracleFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/TWAPOracleFacet.t.sol
@@ -17,7 +17,10 @@ contract TWAPOracleDollar3poolFacetTest is DiamondTestSetup {
             new MockMetaPool(address(dollarToken), curve3CRVTokenAddress)
         );
         vm.prank(owner);
-        ITWAPOracleDollar3pool.setPool(metaPoolAddress, curve3CRVTokenAddress);
+        twapOracleDollar3PoolFacet.setPool(
+            metaPoolAddress,
+            curve3CRVTokenAddress
+        );
     }
 
     function test_overall() public {
@@ -35,12 +38,12 @@ contract TWAPOracleDollar3poolFacetTest is DiamondTestSetup {
             _twap_balances,
             _dy_values
         );
-        ITWAPOracleDollar3pool.update();
+        twapOracleDollar3PoolFacet.update();
 
-        uint256 amount0Out = ITWAPOracleDollar3pool.consult(
+        uint256 amount0Out = twapOracleDollar3PoolFacet.consult(
             address(dollarToken)
         );
-        uint256 amount1Out = ITWAPOracleDollar3pool.consult(
+        uint256 amount1Out = twapOracleDollar3PoolFacet.consult(
             curve3CRVTokenAddress
         );
         assertEq(amount0Out, 100e18);

--- a/packages/contracts/test/diamond/facets/TWAPOracleFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/TWAPOracleFacet.t.sol
@@ -5,7 +5,7 @@ import {IMetaPool} from "../../../src/dollar/interfaces/IMetaPool.sol";
 import {MockMetaPool} from "../../../src/dollar/mocks/MockMetaPool.sol";
 import "../DiamondTestSetup.sol";
 
-contract TWAPOracleDollar3poolFacetTest is DiamondSetup {
+contract TWAPOracleDollar3poolFacetTest is DiamondTestSetup {
     address curve3CRVTokenAddress = address(0x333);
     address twapOracleAddress;
     address metaPoolAddress;

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -89,7 +89,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         );
         //
         metapool = IMetaPool(IManager.stableSwapMetaPoolAddress());
-        metapool.transfer(address(IStakingFacet), 100e18);
+        metapool.transfer(address(stakingFacet), 100e18);
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
         vm.prank(owner);

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -68,7 +68,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         }
 
         vm.startPrank(admin);
-        IManager.setStakingShareAddress(address(stakingShare));
+        managerFacet.setStakingShareAddress(address(stakingShare));
         stakingShare.setApprovalForAll(address(diamond), true);
         IAccessControl.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
@@ -80,7 +80,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
             new MockMetaPool(address(diamond), address(crvToken))
         );
         //vm.prank(admin);
-        IManager.deployStableSwapPool(
+        managerFacet.deployStableSwapPool(
             address(curvePoolFactory),
             curve3CrvBasePool,
             curve3CrvToken,
@@ -88,7 +88,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
             50000000
         );
         //
-        metapool = IMetaPool(IManager.stableSwapMetaPoolAddress());
+        metapool = IMetaPool(managerFacet.stableSwapMetaPoolAddress());
         metapool.transfer(address(stakingFacet), 100e18);
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
@@ -108,7 +108,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
             GOVERNANCE_TOKEN_BURNER_ROLE,
             address(diamond)
         );
-        IManager.setCreditTokenAddress(address(creditToken));
+        managerFacet.setCreditTokenAddress(address(creditToken));
 
         vm.stopPrank();
 
@@ -270,7 +270,9 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         ubiquityPoolFacet.mintDollar(address(collateral), 10 ether, 0 ether);
         uint256 balanceBefore = dollarToken.balanceOf(fourthAccount);
         vm.stopPrank();
-        MockMetaPool mock = MockMetaPool(IManager.stableSwapMetaPoolAddress());
+        MockMetaPool mock = MockMetaPool(
+            managerFacet.stableSwapMetaPoolAddress()
+        );
         // set the mock data for meta pool
         uint256[2] memory _price_cumulative_last = [
             uint256(100e18),
@@ -310,7 +312,9 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         uint256 balanceBefore = dollarToken.balanceOf(fourthAccount);
         uint256 balanceCollateralBefore = collateral.balanceOf(fourthAccount);
         vm.stopPrank();
-        MockMetaPool mock = MockMetaPool(IManager.stableSwapMetaPoolAddress());
+        MockMetaPool mock = MockMetaPool(
+            managerFacet.stableSwapMetaPoolAddress()
+        );
         // set the mock data for meta pool
         uint256[2] memory _price_cumulative_last = [
             uint256(100e18),

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -150,29 +150,29 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
 
     function test_setRedeemActiveShouldWorkIfAdmin() public {
         vm.prank(admin);
-        IUbiquityPoolFacet.setRedeemActive(address(0x333), true);
-        assertEq(IUbiquityPoolFacet.getRedeemActive(address(0x333)), true);
+        ubiquityPoolFacet.setRedeemActive(address(0x333), true);
+        assertEq(ubiquityPoolFacet.getRedeemActive(address(0x333)), true);
     }
 
     function test_setRedeemActiveShouldFailIfNotAdmin() public {
         vm.expectRevert("Manager: Caller is not admin");
-        IUbiquityPoolFacet.setRedeemActive(address(0x333), true);
+        ubiquityPoolFacet.setRedeemActive(address(0x333), true);
     }
 
     function test_setMintActiveShouldWorkIfAdmin() public {
         vm.prank(admin);
-        IUbiquityPoolFacet.setMintActive(address(0x333), true);
-        assertEq(IUbiquityPoolFacet.getMintActive(address(0x333)), true);
+        ubiquityPoolFacet.setMintActive(address(0x333), true);
+        assertEq(ubiquityPoolFacet.getMintActive(address(0x333)), true);
     }
 
     function test_setMintActiveShouldFailIfNotAdmin() public {
         vm.expectRevert("Manager: Caller is not admin");
-        IUbiquityPoolFacet.setMintActive(address(0x333), true);
+        ubiquityPoolFacet.setMintActive(address(0x333), true);
     }
 
     function test_addTokenShouldWorkIfAdmin() public {
         vm.prank(admin);
-        IUbiquityPoolFacet.addToken(
+        ubiquityPoolFacet.addToken(
             address(dollarToken),
             IMetaPool(metaPoolAddress)
         );
@@ -181,18 +181,15 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
     function test_addTokenWithZeroAddressFail() public {
         vm.startPrank(admin);
         vm.expectRevert("0 address detected");
-        IUbiquityPoolFacet.addToken(address(0), IMetaPool(metaPoolAddress));
+        ubiquityPoolFacet.addToken(address(0), IMetaPool(metaPoolAddress));
         vm.expectRevert("0 address detected");
-        IUbiquityPoolFacet.addToken(
-            address(dollarToken),
-            IMetaPool(address(0))
-        );
+        ubiquityPoolFacet.addToken(address(dollarToken), IMetaPool(address(0)));
         vm.stopPrank();
     }
 
     function test_addTokenShouldFailIfNotAdmin() public {
         vm.expectRevert("Manager: Caller is not admin");
-        IUbiquityPoolFacet.addToken(
+        ubiquityPoolFacet.addToken(
             address(dollarToken),
             IMetaPool(address(0x444))
         );
@@ -202,13 +199,13 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         MockERC20 collateral = new MockERC20("collateral", "collateral", 18);
         collateral.mint(fourthAccount, 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.addToken(address(collateral), (metapool));
+        ubiquityPoolFacet.addToken(address(collateral), (metapool));
         vm.prank(admin);
-        IUbiquityPoolFacet.setMintActive(address(collateral), true);
+        ubiquityPoolFacet.setMintActive(address(collateral), true);
         vm.startPrank(fourthAccount);
-        collateral.approve(address(IUbiquityPoolFacet), type(uint256).max);
+        collateral.approve(address(ubiquityPoolFacet), type(uint256).max);
         vm.expectRevert("Slippage limit reached");
-        IUbiquityPoolFacet.mintDollar(
+        ubiquityPoolFacet.mintDollar(
             address(collateral),
             10 ether,
             10000 ether
@@ -220,15 +217,15 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         MockERC20 collateral = new MockERC20("collateral", "collateral", 18);
         collateral.mint(fourthAccount, 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.addToken(address(collateral), (metapool));
+        ubiquityPoolFacet.addToken(address(collateral), (metapool));
         assertEq(collateral.balanceOf(fourthAccount), 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.setMintActive(address(collateral), true);
+        ubiquityPoolFacet.setMintActive(address(collateral), true);
         vm.startPrank(fourthAccount);
-        collateral.approve(address(IUbiquityPoolFacet), type(uint256).max);
+        collateral.approve(address(ubiquityPoolFacet), type(uint256).max);
 
         uint256 balanceBefore = dollarToken.balanceOf(fourthAccount);
-        IUbiquityPoolFacet.mintDollar(address(collateral), 1 ether, 0 ether);
+        ubiquityPoolFacet.mintDollar(address(collateral), 1 ether, 0 ether);
         assertGt(dollarToken.balanceOf(fourthAccount), balanceBefore);
         vm.stopPrank();
     }
@@ -237,25 +234,25 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         MockERC20 collateral = new MockERC20("collateral", "collateral", 18);
         collateral.mint(fourthAccount, 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.addToken(address(collateral), (metapool));
+        ubiquityPoolFacet.addToken(address(collateral), (metapool));
         assertEq(collateral.balanceOf(fourthAccount), 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.setMintActive(address(collateral), true);
+        ubiquityPoolFacet.setMintActive(address(collateral), true);
         vm.startPrank(fourthAccount);
-        collateral.approve(address(IUbiquityPoolFacet), type(uint256).max);
+        collateral.approve(address(ubiquityPoolFacet), type(uint256).max);
 
         uint256 balanceBefore = dollarToken.balanceOf(fourthAccount);
-        IUbiquityPoolFacet.mintDollar(address(collateral), 1 ether, 0 ether);
+        ubiquityPoolFacet.mintDollar(address(collateral), 1 ether, 0 ether);
         assertGt(dollarToken.balanceOf(fourthAccount), balanceBefore);
         vm.stopPrank();
 
         vm.prank(admin);
-        IUbiquityPoolFacet.setRedeemActive(address(collateral), true);
+        ubiquityPoolFacet.setRedeemActive(address(collateral), true);
         vm.startPrank(fourthAccount);
         vm.expectRevert(
             "Ubiquity Dollar Token value must be less than 1 USD to redeem"
         );
-        IUbiquityPoolFacet.redeemDollar(address(collateral), 1 ether, 0 ether);
+        ubiquityPoolFacet.redeemDollar(address(collateral), 1 ether, 0 ether);
         vm.stopPrank();
     }
 
@@ -263,14 +260,14 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         MockERC20 collateral = new MockERC20("collateral", "collateral", 18);
         collateral.mint(fourthAccount, 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.addToken(address(collateral), (metapool));
+        ubiquityPoolFacet.addToken(address(collateral), (metapool));
         assertEq(collateral.balanceOf(fourthAccount), 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.setMintActive(address(collateral), true);
+        ubiquityPoolFacet.setMintActive(address(collateral), true);
         vm.startPrank(fourthAccount);
-        collateral.approve(address(IUbiquityPoolFacet), type(uint256).max);
+        collateral.approve(address(ubiquityPoolFacet), type(uint256).max);
 
-        IUbiquityPoolFacet.mintDollar(address(collateral), 10 ether, 0 ether);
+        ubiquityPoolFacet.mintDollar(address(collateral), 10 ether, 0 ether);
         uint256 balanceBefore = dollarToken.balanceOf(fourthAccount);
         vm.stopPrank();
         MockMetaPool mock = MockMetaPool(IManager.stableSwapMetaPoolAddress());
@@ -290,9 +287,9 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         );
         ITWAPOracleDollar3pool.update();
         vm.prank(admin);
-        IUbiquityPoolFacet.setRedeemActive(address(collateral), true);
+        ubiquityPoolFacet.setRedeemActive(address(collateral), true);
         vm.startPrank(fourthAccount);
-        IUbiquityPoolFacet.redeemDollar(address(collateral), 1 ether, 0 ether);
+        ubiquityPoolFacet.redeemDollar(address(collateral), 1 ether, 0 ether);
 
         assertLt(dollarToken.balanceOf(fourthAccount), balanceBefore);
         vm.stopPrank();
@@ -302,14 +299,14 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         MockERC20 collateral = new MockERC20("collateral", "collateral", 18);
         collateral.mint(fourthAccount, 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.addToken(address(collateral), (metapool));
+        ubiquityPoolFacet.addToken(address(collateral), (metapool));
         assertEq(collateral.balanceOf(fourthAccount), 10 ether);
         vm.prank(admin);
-        IUbiquityPoolFacet.setMintActive(address(collateral), true);
+        ubiquityPoolFacet.setMintActive(address(collateral), true);
         vm.startPrank(fourthAccount);
-        collateral.approve(address(IUbiquityPoolFacet), type(uint256).max);
+        collateral.approve(address(ubiquityPoolFacet), type(uint256).max);
 
-        IUbiquityPoolFacet.mintDollar(address(collateral), 10 ether, 0 ether);
+        ubiquityPoolFacet.mintDollar(address(collateral), 10 ether, 0 ether);
         uint256 balanceBefore = dollarToken.balanceOf(fourthAccount);
         uint256 balanceCollateralBefore = collateral.balanceOf(fourthAccount);
         vm.stopPrank();
@@ -330,12 +327,12 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         );
         ITWAPOracleDollar3pool.update();
         vm.prank(admin);
-        IUbiquityPoolFacet.setRedeemActive(address(collateral), true);
+        ubiquityPoolFacet.setRedeemActive(address(collateral), true);
         vm.startPrank(fourthAccount);
-        IUbiquityPoolFacet.redeemDollar(address(collateral), 1 ether, 0 ether);
+        ubiquityPoolFacet.redeemDollar(address(collateral), 1 ether, 0 ether);
 
         assertLt(dollarToken.balanceOf(fourthAccount), balanceBefore);
-        IUbiquityPoolFacet.collectRedemption(address(collateral));
+        ubiquityPoolFacet.collectRedemption(address(collateral));
         assertGt(collateral.balanceOf(fourthAccount), balanceCollateralBefore);
         vm.stopPrank();
     }

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -70,7 +70,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         vm.startPrank(admin);
         managerFacet.setStakingShareAddress(address(stakingShare));
         stakingShare.setApprovalForAll(address(diamond), true);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(stakingShare)
         );
@@ -97,14 +97,14 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
 
         vm.startPrank(admin);
 
-        IAccessControl.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
-        IAccessControl.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(GOVERNANCE_TOKEN_MANAGER_ROLE, admin);
+        accessControlFacet.grantRole(CREDIT_NFT_MANAGER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
 
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_BURNER_ROLE,
             address(diamond)
         );

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -14,7 +14,7 @@ import {BondingShare} from "../../../src/dollar/mocks/MockShareV1.sol";
 import {DollarMintCalculatorFacet} from "../../../src/dollar/facets/DollarMintCalculatorFacet.sol";
 import {UbiquityCreditToken} from "../../../src/dollar/core/UbiquityCreditToken.sol";
 
-contract UbiquityPoolFacetTest is DiamondSetup {
+contract UbiquityPoolFacetTest is DiamondTestSetup {
     MockERC20 crvToken;
     address curve3CrvToken;
     address metaPoolAddress;

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -39,7 +39,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
 
         vm.startPrank(owner);
 
-        ITWAPOracleDollar3pool.setPool(metaPoolAddress, curve3CrvToken);
+        twapOracleDollar3PoolFacet.setPool(metaPoolAddress, curve3CrvToken);
 
         address[7] memory mintings = [
             admin,
@@ -93,7 +93,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         metapool.transfer(secondAccount, 1000e18);
         vm.stopPrank();
         vm.prank(owner);
-        ITWAPOracleDollar3pool.setPool(address(metapool), curve3CrvToken);
+        twapOracleDollar3PoolFacet.setPool(address(metapool), curve3CrvToken);
 
         vm.startPrank(admin);
 
@@ -285,7 +285,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
             _twap_balances,
             _dy_values
         );
-        ITWAPOracleDollar3pool.update();
+        twapOracleDollar3PoolFacet.update();
         vm.prank(admin);
         ubiquityPoolFacet.setRedeemActive(address(collateral), true);
         vm.startPrank(fourthAccount);
@@ -325,7 +325,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
             _twap_balances,
             _dy_values
         );
-        ITWAPOracleDollar3pool.update();
+        twapOracleDollar3PoolFacet.update();
         vm.prank(admin);
         ubiquityPoolFacet.setRedeemActive(address(collateral), true);
         vm.startPrank(fourthAccount);

--- a/packages/contracts/test/dollar/DirectGovernanceFarmer.t.sol
+++ b/packages/contracts/test/dollar/DirectGovernanceFarmer.t.sol
@@ -59,7 +59,7 @@ contract DirectGovernanceFarmerTest is LocalTestHelper {
 
     function setUp() public override {
         super.setUp();
-        dollarManagerAddress = address(IManager);
+        dollarManagerAddress = address(managerFacet);
         dollar = IERC20Ubiquity(
             IUbiquityDollarManager(dollarManagerAddress).dollarTokenAddress()
         );
@@ -94,7 +94,7 @@ contract DirectGovernanceFarmerTest is LocalTestHelper {
         );
         // create direct governance farmer contract instance
         directGovernanceFarmer = new DirectGovernanceFarmer(
-            IUbiquityDollarManager(address(IManager)),
+            IUbiquityDollarManager(address(managerFacet)),
             base3PoolAddress,
             depositZapAddress
         );
@@ -585,7 +585,7 @@ contract DirectGovernanceFarmerTest is LocalTestHelper {
     function testIsIdIncludedReturnTrueIfIdIsInTheList() public {
         // deploy contract with exposed internal methods
         DirectGovernanceFarmerHarness directGovernanceFarmerHarness = new DirectGovernanceFarmerHarness(
-                IUbiquityDollarManager(address(IManager)),
+                IUbiquityDollarManager(address(managerFacet)),
                 base3PoolAddress,
                 depositZapAddress
             );
@@ -598,7 +598,7 @@ contract DirectGovernanceFarmerTest is LocalTestHelper {
     function testIsIdIncludedReturnFalseIfIdIsNotInTheList() public {
         // deploy contract with exposed internal methods
         DirectGovernanceFarmerHarness directGovernanceFarmerHarness = new DirectGovernanceFarmerHarness(
-                IUbiquityDollarManager(address(IManager)),
+                IUbiquityDollarManager(address(managerFacet)),
                 base3PoolAddress,
                 depositZapAddress
             );

--- a/packages/contracts/test/dollar/core/CreditNft.t.sol
+++ b/packages/contracts/test/dollar/core/CreditNft.t.sol
@@ -28,7 +28,7 @@ contract CreditNftTest is LocalTestHelper {
         // deploy Credit NFT token
         creditNftAddress = address(creditNft);
         vm.prank(admin);
-        IManager.setCreditNftAddress(address(creditNftAddress));
+        managerFacet.setCreditNftAddress(address(creditNftAddress));
     }
 
     function testSetManager_ShouldRevert_WhenNotAdmin() public {

--- a/packages/contracts/test/dollar/core/StakingShare.t.sol
+++ b/packages/contracts/test/dollar/core/StakingShare.t.sol
@@ -38,7 +38,10 @@ contract DepositStakingShare is LocalTestHelper {
         super.setUp();
         // grant diamond token staking share right rights
         vm.prank(admin);
-        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(diamond));
+        accessControlFacet.grantRole(
+            STAKING_SHARE_MINTER_ROLE,
+            address(diamond)
+        );
         metapool = IMetaPool(metaPoolAddress);
         fourthBal = metapool.balanceOf(fourthAccount);
         minBal = metapool.balanceOf(stakingMinAccount);
@@ -82,7 +85,7 @@ contract StakingShareTest is DepositStakingShare {
         uint256 end
     ) public {
         vm.prank(admin);
-        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        accessControlFacet.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
         vm.prank(admin);
         stakingShare.updateStake(1, uint256(amount), uint256(debt), end);
         StakingShare.Stake memory stake = stakingShare.getStake(1);
@@ -120,7 +123,7 @@ contract StakingShareTest is DepositStakingShare {
         uint256 end
     ) public {
         vm.prank(admin);
-        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        accessControlFacet.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
         vm.prank(admin);
         uint256 id = stakingShare.mint(
             secondAccount,
@@ -175,33 +178,33 @@ contract StakingShareTest is DepositStakingShare {
         emit Paused(admin);
 
         vm.prank(admin);
-        IAccessControl.pause();
+        accessControlFacet.pause();
     }
 
     function testPause_ShouldRevert_IfNotPauser() public {
         vm.expectRevert("Manager: Caller is not admin");
         vm.prank(secondAccount);
-        IAccessControl.pause();
+        accessControlFacet.pause();
     }
 
     function testUnpause_ShouldUnpause() public {
         vm.prank(admin);
-        IAccessControl.pause();
+        accessControlFacet.pause();
 
         vm.expectEmit(true, false, false, true);
         emit Unpaused(admin);
 
         vm.prank(admin);
-        IAccessControl.unpause();
+        accessControlFacet.unpause();
     }
 
     function testUnpause_ShouldRevert_IfNotPauser() public {
         vm.prank(admin);
-        IAccessControl.pause();
+        accessControlFacet.pause();
 
         vm.expectRevert("Manager: Caller is not admin");
         vm.prank(secondAccount);
-        IAccessControl.unpause();
+        accessControlFacet.unpause();
     }
 
     function testSafeTransferFrom_ShouldTransferTokenId() public {
@@ -328,7 +331,7 @@ contract StakingShareTest is DepositStakingShare {
 
     function testSetUri_ShouldSetUri() public {
         vm.prank(admin);
-        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        accessControlFacet.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
 
         string memory stringTest = "{'name':'Staking Share','description':,"
         "'Ubiquity Staking Share',"
@@ -344,7 +347,7 @@ contract StakingShareTest is DepositStakingShare {
 
     function testSetBaseUri_ShouldSetUri() public {
         vm.prank(admin);
-        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        accessControlFacet.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
 
         string memory stringTest = "{'name':'Staking Share','description':,"
         "'Ubiquity Staking Share',"
@@ -360,7 +363,7 @@ contract StakingShareTest is DepositStakingShare {
 
     function testSetUriSingle_ShouldSetUri() public {
         vm.prank(admin);
-        IAccessControl.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
+        accessControlFacet.grantRole(STAKING_SHARE_MINTER_ROLE, address(admin));
 
         string memory stringTest = "{'name':'Staking Share','description':,"
         "'Ubiquity Staking Share',"

--- a/packages/contracts/test/dollar/core/StakingShare.t.sol
+++ b/packages/contracts/test/dollar/core/StakingShare.t.sol
@@ -311,7 +311,7 @@ contract StakingShareTest is DepositStakingShare {
             fourthAccount,
             fourthBal,
             creationBlock[1],
-            IStakingFormulasFacet.durationMultiply(
+            stakingFormulasFacet.durationMultiply(
                 fourthBal,
                 52,
                 IStakingFacet.stakingDiscountMultiplier()

--- a/packages/contracts/test/dollar/core/StakingShare.t.sol
+++ b/packages/contracts/test/dollar/core/StakingShare.t.sol
@@ -64,9 +64,9 @@ contract DepositStakingShare is LocalTestHelper {
 
         for (uint256 i; i < depositingAccounts.length; ++i) {
             vm.startPrank(depositingAccounts[i]);
-            metapool.approve(address(IStakingFacet), 2 ** 256 - 1);
+            metapool.approve(address(stakingFacet), 2 ** 256 - 1);
             creationBlock.push(block.number);
-            IStakingFacet.deposit(depositAmounts[i], lockupWeeks[i]);
+            stakingFacet.deposit(depositAmounts[i], lockupWeeks[i]);
             vm.stopPrank();
         }
     }
@@ -314,9 +314,9 @@ contract StakingShareTest is DepositStakingShare {
             stakingFormulasFacet.durationMultiply(
                 fourthBal,
                 52,
-                IStakingFacet.stakingDiscountMultiplier()
+                stakingFacet.stakingDiscountMultiplier()
             ),
-            IStakingFacet.blockCountInAWeek() * 52,
+            stakingFacet.blockCountInAWeek() * 52,
             fourthBal
         );
 

--- a/packages/contracts/test/dollar/core/UbiquityDollarToken.t.sol
+++ b/packages/contracts/test/dollar/core/UbiquityDollarToken.t.sol
@@ -35,7 +35,7 @@ contract UbiquityDollarTokenTest is LocalTestHelper {
         vm.startPrank(admin);
         dollar_addr = address(dollarToken);
 
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             keccak256("GOVERNANCE_TOKEN_MANAGER_ROLE"),
             admin
         );

--- a/packages/contracts/test/dollar/core/UbiquityGovernanceToken.t.sol
+++ b/packages/contracts/test/dollar/core/UbiquityGovernanceToken.t.sol
@@ -13,7 +13,7 @@ contract UbiquityGovernanceTokenTest is LocalTestHelper {
     function setUp() public override {
         super.setUp();
         vm.startPrank(admin);
-        IAccessControl.grantRole(
+        accessControlFacet.grantRole(
             keccak256("GOVERNANCE_TOKEN_MANAGER_ROLE"),
             admin
         );

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -27,7 +27,7 @@ abstract contract LocalTestHelper is DiamondTestSetup {
         super.setUp();
 
         creditNftRedemptionCalculator = ICreditNftRedemptionCalculationFacet;
-        creditRedemptionCalculator = ICreditRedemptionCalculationFacet;
+        creditRedemptionCalculator = creditRedemptionCalculationFacet;
         dollarMintCalculator = dollarMintCalculatorFacet;
         creditNftManager = ICreditNftManagerFacet;
         dollarMintExcess = dollarMintExcessFacet;

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -26,7 +26,7 @@ abstract contract LocalTestHelper is DiamondTestSetup {
     function setUp() public virtual override {
         super.setUp();
 
-        creditNftRedemptionCalculator = ICreditNftRedemptionCalculationFacet;
+        creditNftRedemptionCalculator = creditNftRedemptionCalculationFacet;
         creditRedemptionCalculator = creditRedemptionCalculationFacet;
         dollarMintCalculator = dollarMintCalculatorFacet;
         creditNftManager = ICreditNftManagerFacet;

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -63,7 +63,7 @@ abstract contract LocalTestHelper is DiamondTestSetup {
         // deploy credit token
 
         // set treasury address
-        IManager.setTreasuryAddress(treasuryAddress);
+        managerFacet.setTreasuryAddress(treasuryAddress);
 
         vm.stopPrank();
         vm.prank(owner);

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -16,8 +16,6 @@ abstract contract LocalTestHelper is DiamondTestSetup {
     address curve3CRVTokenAddress = address(0x101);
     address public treasuryAddress = address(0x111222333);
 
-    TWAPOracleDollar3poolFacet twapOracle;
-
     CreditNftRedemptionCalculatorFacet creditNftRedemptionCalculator;
     CreditRedemptionCalculatorFacet creditRedemptionCalculator;
     DollarMintCalculatorFacet dollarMintCalculator;
@@ -28,7 +26,6 @@ abstract contract LocalTestHelper is DiamondTestSetup {
     function setUp() public virtual override {
         super.setUp();
 
-        twapOracle = ITWAPOracleDollar3pool;
         creditNftRedemptionCalculator = ICreditNftRedemptionCalculationFacet;
         creditRedemptionCalculator = ICreditRedemptionCalculationFacet;
         dollarMintCalculator = IDollarMintCalcFacet;
@@ -70,7 +67,10 @@ abstract contract LocalTestHelper is DiamondTestSetup {
 
         vm.stopPrank();
         vm.prank(owner);
-        ITWAPOracleDollar3pool.setPool(metaPoolAddress, curve3CRVTokenAddress);
-        ITWAPOracleDollar3pool.update();
+        twapOracleDollar3PoolFacet.setPool(
+            metaPoolAddress,
+            curve3CRVTokenAddress
+        );
+        twapOracleDollar3PoolFacet.update();
     }
 }

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -28,7 +28,7 @@ abstract contract LocalTestHelper is DiamondTestSetup {
 
         creditNftRedemptionCalculator = ICreditNftRedemptionCalculationFacet;
         creditRedemptionCalculator = ICreditRedemptionCalculationFacet;
-        dollarMintCalculator = IDollarMintCalcFacet;
+        dollarMintCalculator = dollarMintCalculatorFacet;
         creditNftManager = ICreditNftManagerFacet;
         dollarMintExcess = dollarMintExcessFacet;
 

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -30,7 +30,7 @@ abstract contract LocalTestHelper is DiamondTestSetup {
         creditRedemptionCalculator = ICreditRedemptionCalculationFacet;
         dollarMintCalculator = IDollarMintCalcFacet;
         creditNftManager = ICreditNftManagerFacet;
-        dollarMintExcess = IDollarMintExcessFacet;
+        dollarMintExcess = dollarMintExcessFacet;
 
         vm.startPrank(admin);
 

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -29,7 +29,7 @@ abstract contract LocalTestHelper is DiamondTestSetup {
         creditNftRedemptionCalculator = creditNftRedemptionCalculationFacet;
         creditRedemptionCalculator = creditRedemptionCalculationFacet;
         dollarMintCalculator = dollarMintCalculatorFacet;
-        creditNftManager = ICreditNftManagerFacet;
+        creditNftManager = creditNftManagerFacet;
         dollarMintExcess = dollarMintExcessFacet;
 
         vm.startPrank(admin);

--- a/packages/contracts/test/helpers/LocalTestHelper.sol
+++ b/packages/contracts/test/helpers/LocalTestHelper.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.19;
 
 import {MockTWAPOracleDollar3pool} from "../../src/dollar/mocks/MockTWAPOracleDollar3pool.sol";
-import {DiamondSetup} from "../diamond/DiamondTestSetup.sol";
+import {DiamondTestSetup} from "../diamond/DiamondTestSetup.sol";
 import {TWAPOracleDollar3poolFacet} from "../../src/dollar/facets/TWAPOracleDollar3poolFacet.sol";
 import {CreditRedemptionCalculatorFacet} from "../../src/dollar/facets/CreditRedemptionCalculatorFacet.sol";
 import {CreditNftRedemptionCalculatorFacet} from "../../src/dollar/facets/CreditNftRedemptionCalculatorFacet.sol";
@@ -11,7 +11,7 @@ import {CreditNftManagerFacet} from "../../src/dollar/facets/CreditNftManagerFac
 import {DollarMintExcessFacet} from "../../src/dollar/facets/DollarMintExcessFacet.sol";
 import {MockMetaPool} from "../../src/dollar/mocks/MockMetaPool.sol";
 
-abstract contract LocalTestHelper is DiamondSetup {
+abstract contract LocalTestHelper is DiamondTestSetup {
     address public constant NATIVE_ASSET = address(0);
     address curve3CRVTokenAddress = address(0x101);
     address public treasuryAddress = address(0x111222333);


### PR DESCRIPTION
This PR refactors [DiamondTestSetup](https://github.com/rndquu/ubiquity-dollar/blob/8a4fc742ea380d1f8a8ebc825ebabfb448a3ab3d/packages/contracts/test/diamond/DiamondTestSetup.sol) so that all variables started with a lower case letter. The original [DiamondTestSetup](https://github.com/ubiquity/ubiquity-dollar/blob/d41cc0dbb6cb70ff8edd8c9b3487a66db56f132f/packages/contracts/test/diamond/DiamondTestSetup.sol) has [variables](https://github.com/ubiquity/ubiquity-dollar/blob/d41cc0dbb6cb70ff8edd8c9b3487a66db56f132f/packages/contracts/test/diamond/DiamondTestSetup.sol#L64) which start with an upper case letter so it is not clear whether it is an interface or a variable. 