### PR TITLE
fix incorrect coverage values in the compare test coverage workflow

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -36,10 +36,6 @@ jobs:
           # generates lcov.info
           forge build && forge coverage --report lcov
 
-          # Foundry uses relative paths but Hardhat uses absolute paths.
-          # Convert absolute paths to relative paths for consistency.
-          sed -i -e 's/\/.*solidity.//g' lcov.info
-
           # Merge lcov files
           lcov \
               --rc lcov_branch_coverage=1 \
@@ -78,10 +74,6 @@ jobs:
         run: |
           # generates lcov.info
           forge build && forge coverage --report lcov
-
-          # Foundry uses relative paths but Hardhat uses absolute paths.
-          # Convert absolute paths to relative paths for consistency.
-          sed -i -e 's/\/.*solidity.//g' lcov.info
 
           # Merge lcov files
           lcov \

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -19,6 +19,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: development
+          path: development
+
+      - name: Checkout code in PR branch
+        uses: actions/checkout@v3
+        with:
+          path: pr
 
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -30,11 +36,10 @@ jobs:
 
       - name: Get development branch coverage
         id: coverage-development
+        working-directory: development/packages/contracts
         run: |
-          cd ./packages/contracts
-
           # generates lcov.info
-          forge coverage --report lcov
+          forge build && forge coverage --report lcov
 
           # Foundry uses relative paths but Hardhat uses absolute paths.
           # Convert absolute paths to relative paths for consistency.
@@ -58,7 +63,6 @@ jobs:
                   "src/dollar/mocks/*" \
                   "src/dollar/utils/*" \
                   "test/*" \
-
 
           # Generate summary
           COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
@@ -67,20 +71,12 @@ jobs:
 
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
-      - name: Checkout code in PR branch
-        uses: actions/checkout@v3
-
-      - name: Update Forge Dependencies
-        working-directory: packages/contracts
-        run: forge update lib/forge-std
-
       - name: Get PR branch coverage
         id: coverage-pr
+        working-directory: pr/packages/contracts
         run: |
-          cd ./packages/contracts
-
           # generates lcov.info
-          forge coverage --report lcov
+          forge build && forge coverage --report lcov
 
           # Foundry uses relative paths but Hardhat uses absolute paths.
           # Convert absolute paths to relative paths for consistency.
@@ -104,7 +100,6 @@ jobs:
                   "src/dollar/mocks/*" \
                   "src/dollar/utils/*" \
                   "test/*" \
-
 
           # Generate summary
           COVERAGE_DEVELOPMENT_OUTPUT=$(lcov \
@@ -126,4 +121,4 @@ jobs:
       - name: Upload test coverage report to coveralls.io
         uses: coverallsapp/github-action@v2
         with:
-          file: packages/contracts/filtered-lcov.info
+          file: pr/packages/contracts/filtered-lcov.info

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -21,11 +21,6 @@ jobs:
           ref: development
           path: development
 
-      - name: Checkout code in PR branch
-        uses: actions/checkout@v3
-        with:
-          path: pr
-
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -71,9 +66,15 @@ jobs:
 
           echo COVERAGE=$(echo "${COVERAGE_DEVELOPMENT_OUTPUT}" | tail -n 1 | cut -d % -f 1 | cut -d \| -f 2) >> $GITHUB_OUTPUT
 
+      - name: Delete development branch folder
+        run: rm -rf development
+
+      - name: Checkout code in PR branch
+        uses: actions/checkout@v3
+
       - name: Get PR branch coverage
         id: coverage-pr
-        working-directory: pr/packages/contracts
+        working-directory: packages/contracts
         run: |
           # generates lcov.info
           forge build && forge coverage --report lcov
@@ -121,4 +122,4 @@ jobs:
       - name: Upload test coverage report to coveralls.io
         uses: coverallsapp/github-action@v2
         with:
-          file: pr/packages/contracts/filtered-lcov.info
+          file: packages/contracts/filtered-lcov.info


### PR DESCRIPTION
- fetch development and pull request branches to separate folders
- set working-directory during get coverage steps
- forge build before forge coverage to be able to access JSON ABI facet contracts

Resolves: #826
