### PR TITLE
Feature/format contracts prettier plugin solidity

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "cspell --no-must-find-files"
     ],
     "*.sol": [
-      "prettier --write",
+      "prettier --plugin=prettier-plugin-solidity --write",
       "cspell --no-must-find-files"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint-staged": "^13.0.3",
     "nodemon": "^2.0.19",
     "prettier": "2.8.8",
-    "prettier-plugin-solidity": "1.1.3",
+    "prettier-plugin-solidity": "^1.2.0",
     "rimraf": "3.0.2",
     "yarn-audit-fix": "^9.3.7"
   },
@@ -34,7 +34,7 @@
     "dev:dapp": "yarn workspace @ubiquity/dapp run start",
     "test:all": "yarn workspace @ubiquity/contracts run test:unit",
     "coverage": "yarn workspace @ubiquity/contracts run test:coverage",
-    "format:all": "prettier packages/ --write",
+    "format:all": "yarn workspaces foreach run format",
     "clean:all": "yarn workspaces foreach run clean && rimraf node_modules",
     "lint:all": "yarn workspaces foreach run lint",
     "build:ci:netlify": "yarn build:all",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -34,6 +34,7 @@
     "clean:forge": "forge clean",
     "build": "forge build",
     "forge:install": "forge install",
+    "format": "prettier --plugin=prettier-plugin-solidity src/**/*.sol test/**/*.sol --write",
     "docs": "FOUNDRY_PROFILE=docs forge doc --build",
     "_hardhat-task": "tsx ./scripts/task/task.ts"
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -68,7 +68,8 @@
     "@types/react-transition-group": "^4",
     "cspell": "latest",
     "glob": "^10.3.0",
-    "prettier-plugin-solidity": "^1.1.2",
+    "prettier": "^3.1.0",
+    "prettier-plugin-solidity": "^1.2.0",
     "typescript": "^4.9.4"
   }
 }

--- a/packages/contracts/src/dollar/interfaces/IUbiquityGovernance.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityGovernance.sol
@@ -6,6 +6,4 @@ import "./IERC20Ubiquity.sol";
 /**
  * @notice Ubiquity Governance token interface
  */
-interface IUbiquityGovernanceToken is IERC20Ubiquity {
-
-}
+interface IUbiquityGovernanceToken is IERC20Ubiquity {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2899,12 +2899,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solidity-parser/parser@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "@solidity-parser/parser@npm:0.16.0"
+"@solidity-parser/parser@npm:^0.16.2":
+  version: 0.16.2
+  resolution: "@solidity-parser/parser@npm:0.16.2"
   dependencies:
     antlr4ts: ^0.5.0-alpha.4
-  checksum: 6ccbdab334331a58fde2a739cff76d5a99d836186b7899e8e027266f2af2a4bddc77c9c2abd01307cea6c470345d48edc470049e9672143b73f4aff3c8976183
+  checksum: 109f7bec5de943c63e444fdde179d9bba6a592c18c836f585753798f428424cfcca72c715e7a345e4b79b83d6548543c9e56cb4b263e9b1e8352af2efcfd224a
   languageName: node
   linkType: hard
 
@@ -3757,7 +3757,8 @@ __metadata:
     dotenv: ^16.0.3
     ethers: ^6.6.0
     glob: ^10.3.0
-    prettier-plugin-solidity: ^1.1.2
+    prettier: ^3.1.0
+    prettier-plugin-solidity: ^1.2.0
     react-transition-group: ^4.4.5
     tsx: ^3.12.2
     typescript: ^4.9.4
@@ -3829,7 +3830,7 @@ __metadata:
     lint-staged: ^13.0.3
     nodemon: ^2.0.19
     prettier: 2.8.8
-    prettier-plugin-solidity: 1.1.3
+    prettier-plugin-solidity: ^1.2.0
     rimraf: 3.0.2
     yarn-audit-fix: ^9.3.7
   languageName: unknown
@@ -12154,16 +12155,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-solidity@npm:1.1.3, prettier-plugin-solidity@npm:^1.1.2":
-  version: 1.1.3
-  resolution: "prettier-plugin-solidity@npm:1.1.3"
+"prettier-plugin-solidity@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "prettier-plugin-solidity@npm:1.2.0"
   dependencies:
-    "@solidity-parser/parser": ^0.16.0
-    semver: ^7.3.8
+    "@solidity-parser/parser": ^0.16.2
+    semver: ^7.5.4
     solidity-comments-extractor: ^0.0.7
   peerDependencies:
-    prettier: ">=2.3.0 || >=3.0.0-alpha.0"
-  checksum: d5aadfa411a4d983a2bd204048726fd91fbcaffbfa26d818ef0d6001fb65f82d0eae082e935e96c79e65e09ed979b186311ddb8c38be2f0ce5dd5f5265df77fe
+    prettier: ">=2.3.0"
+  checksum: 96dc9751a7393dfbfb1fcc08d662fd8e69df9ddf51ad70172e6915e86a61491f93f3051ea716deb50ae6023f50b64aa064ffef81224405fba92566124250edb2
   languageName: node
   linkType: hard
 
@@ -12191,6 +12192,15 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: fdc8f2616f099f5f0d685907f4449a70595a0fc1d081a88919604375989e0d5e9168d6121d8cc6861f21990b31665828e00472544d785d5940ea08a17660c3a6
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "prettier@npm:3.1.0"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 44b556bd56f74d7410974fbb2418bb4e53a894d3e7b42f6f87779f69f27a6c272fa7fc27cec0118cd11730ef3246478052e002cbd87e9a253f9cd04a56aa7d9b
   languageName: node
   linkType: hard
 
@@ -13214,6 +13224,17 @@ __metadata:
   bin:
     semver: ./bin/semver.js
   checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #839 

* enforce prettier-plugin-solidity for packages/contracts solidity files
* improve `format:all`
* upgrade prettier-plugin-solidity to 1.2.0

Plus fix prettier output for IUbiquityGovernance.sol