### PR TITLE
ci: fix yarn audit

### DIFF
--- a/.github/workflows/yarn-audit.yml
+++ b/.github/workflows/yarn-audit.yml
@@ -18,5 +18,8 @@ jobs:
         with:
           node-version: "18.14.1"
 
+      - name: Install dependencies
+        run: yarn install
+
       - name: Audit
-        run: yes | npx yarn-audit-fix
+        run: yes | yarn yarn-audit-fix


### PR DESCRIPTION
The "Audit & Fix" workflow fails in the latest PRs ([example](https://github.com/ubiquity/ubiquity-dollar/actions/runs/6977334441/job/18986998238?pr=844)) because the latest yarn (as far as I understand) introduced a [bug](https://github.com/yarnpkg/yarn/issues/9015).

This PR uses a locally installed `yarn-audit-fix` package.