### PR TITLE
feat: add oracle migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,21 @@ ADMIN_PRIVATE_KEY="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b7
 # By default set to LUSD address in ethereum mainnet.
 # - mainnet/anvil(forked from mainnet): 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0 (LUSD)
 # - testnet: 0x3e622317f8C93f7328350cF0B56d9eD4C620C5d6 (DAI)
-# NOTICE: LUSD token is not deployed to sepolia testnet so we test DAI token instead which is deployed to testnet
+# NOTICE: LUSD token is not deployed to sepolia testnet so we use DAI instead which is deployed to testnet
 COLLATERAL_TOKEN_ADDRESS="0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
+
+# Collateral token price feed address from chainlink.
+# By default set to LUSD/USD price feed deployed on ethereum mainnet.
+# - mainnet: uses already deployed LUSD/USD chainlink price feed
+# - testnet/anvil: deploys LUSD/USD chainlink price feed from scratch
+COLLATERAL_TOKEN_CHAINLINK_PRICE_FEED_ADDRESS="0x3D7aE7E594f2f2091Ad8798313450130d0Aba3a0"
+
+# Curve metapool address (Dollar-3CRVLP).
+# By default set to the old Dollar-3CRV metapool which is about to be redeployed when
+# new Dollar token is deployed.
+# - mainnet: uses old Dollar-3CRVLP address
+# - testnet/anvil: deploys metapool from scratch
+CURVE_DOLLAR_METAPOOL_ADDRESS="0x20955CB69Ae1515962177D164dfC9522feef567E"
 
 # Owner private key (grants access to updating Diamond facets and setting TWAP oracle address).
 # By default set to the private key from the 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 address
@@ -101,6 +114,12 @@ OWNER_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f
 # - testnet: https://ethereum-sepolia.publicnode.com
 # - mainnet: https://eth.ubq.fi/v1/mainnet 
 RPC_URL="http://127.0.0.1:8545"
+
+# 3CRV LP token address (which you get if you deposit to Curve's TriPool (DAI/USDC/USDT)).
+# By default set to 3CRV LP token address from mainnet.
+# - mainet: uses values set in TOKEN_3CRV_ADDRESS
+# - testnet/anvil: deploys 3CRV LP token from scratch
+TOKEN_3CRV_ADDRESS="0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
 ```
 
 We provide an `.env.example` file pre-set with recommend testing environment variables but you are free to modify or experiment with different values on your local branch.

--- a/cspell.json
+++ b/cspell.json
@@ -63,6 +63,7 @@
     "connectkit",
     "Consts",
     "Cpath",
+    "CRVLP",
     "crytic",
     "Csvg",
     "delegatecall",

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -10,6 +10,19 @@ ADMIN_PRIVATE_KEY="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b7
 # NOTICE: LUSD token is not deployed to sepolia testnet so we use DAI instead which is deployed to testnet
 COLLATERAL_TOKEN_ADDRESS="0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
 
+# Collateral token price feed address from chainlink.
+# By default set to LUSD/USD price feed deployed on ethereum mainnet.
+# - mainnet: uses already deployed LUSD/USD chainlink price feed
+# - testnet/anvil: deploys LUSD/USD chainlink price feed from scratch
+COLLATERAL_TOKEN_CHAINLINK_PRICE_FEED_ADDRESS="0x3D7aE7E594f2f2091Ad8798313450130d0Aba3a0"
+
+# Curve metapool address (Dollar-3CRVLP).
+# By default set to the old Dollar-3CRV metapool which is about to be redeployed when
+# new Dollar token is deployed.
+# - mainnet: uses old Dollar-3CRVLP address
+# - testnet/anvil: deploys metapool from scratch
+CURVE_DOLLAR_METAPOOL_ADDRESS="0x20955CB69Ae1515962177D164dfC9522feef567E"
+
 # Owner private key (grants access to updating Diamond facets and setting TWAP oracle address).
 # By default set to the private key from the 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 address
 # which is the 1st address derived from test mnemonic "test test test test test test test test test test test junk".
@@ -20,3 +33,9 @@ OWNER_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f
 # - testnet: https://ethereum-sepolia.publicnode.com
 # - mainnet: https://eth.ubq.fi/v1/mainnet 
 RPC_URL="http://127.0.0.1:8545"
+
+# 3CRV LP token address (which you get if you deposit to Curve's TriPool (DAI/USDC/USDT)).
+# By default set to 3CRV LP token address from mainnet.
+# - mainet: uses value set in TOKEN_3CRV_ADDRESS
+# - testnet/anvil: deploys 3CRV LP token from scratch
+TOKEN_3CRV_ADDRESS="0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"

--- a/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
@@ -100,6 +100,9 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
     uint256 ownerPrivateKey;
     address collateralTokenAddress;
 
+    // threshold in seconds when price feed response should be considered stale
+    uint256 CHAINLINK_PRICE_FEED_THRESHOLD;
+
     // Dollar related contracts
     UbiquityDollarToken public dollarToken;
     ERC1967Proxy public proxyDollarToken;
@@ -391,6 +394,9 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         // start sending admin transactions
         vm.startBroadcast(adminPrivateKey);
 
+        // set threshold to 10 years (3650 days) for ease of debugging
+        CHAINLINK_PRICE_FEED_THRESHOLD = 3650 days;
+
         // set params for LUSD/USD chainlink price feed mock
         MockChainLinkFeed(address(chainLinkPriceFeedLusd)).updateMockParams(
             1, // round id
@@ -404,11 +410,11 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
             address(diamond)
         );
 
-        // set price feed address and set threshold to 10 years (3650 days) for ease of debugging
+        // set price feed address and threshold in seconds
         ubiquityPoolFacet.setCollateralChainLinkPriceFeed(
             collateralTokenAddress, // collateral token address
             address(chainLinkPriceFeedLusd), // price feed address
-            3650 days // price feed staleness threshold in seconds
+            CHAINLINK_PRICE_FEED_THRESHOLD // price feed staleness threshold in seconds
         );
 
         // fetch latest prices from chainlink for collateral with index 0

--- a/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
@@ -118,7 +118,7 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
     UbiquityPoolFacet ubiquityPoolFacetImplementation;
 
     // oracle related contracts
-    AggregatorV3Interface chainLinkPriceFeedLusdUsd; // chainlink LUSD/USD price feed
+    AggregatorV3Interface chainLinkPriceFeedLusd; // chainlink LUSD/USD price feed
     IERC20 curveTriPoolLpToken; // Curve's 3CRV-LP token
     IMetaPool curveDollarMetaPool; // Curve's Dollar-3CRVLP metapool
 
@@ -291,7 +291,7 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         uint256 poolCeiling = 10_000e18; // max 10_000 of collateral tokens is allowed
         ubiquityPoolFacet.addCollateralToken(
             collateralTokenAddress, // collateral token address
-            address(chainLinkPriceFeedLusdUsd), // chainlink LUSD/USD price feed address
+            address(chainLinkPriceFeedLusd), // chainlink LUSD/USD price feed address
             poolCeiling // pool ceiling amount
         );
         // enable collateral at index 0
@@ -379,7 +379,7 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         vm.startBroadcast(ownerPrivateKey);
 
         // deploy LUSD/USD chainlink mock price feed
-        chainLinkPriceFeedLusdUsd = new MockChainLinkFeed();
+        chainLinkPriceFeedLusd = new MockChainLinkFeed();
 
         // stop sending owner transactions
         vm.stopBroadcast();
@@ -392,7 +392,7 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         vm.startBroadcast(adminPrivateKey);
 
         // set params for LUSD/USD chainlink price feed mock
-        MockChainLinkFeed(address(chainLinkPriceFeedLusdUsd)).updateMockParams(
+        MockChainLinkFeed(address(chainLinkPriceFeedLusd)).updateMockParams(
             1, // round id
             100_000_000, // answer, 100_000_000 = $1.00 (chainlink 8 decimals answer is converted to 6 decimals used in UbiquityPool)
             block.timestamp, // started at
@@ -407,7 +407,7 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         // set price feed address and set threshold to 10 years (3650 days) for ease of debugging
         ubiquityPoolFacet.setCollateralChainLinkPriceFeed(
             collateralTokenAddress, // collateral token address
-            address(chainLinkPriceFeedLusdUsd), // price feed address
+            address(chainLinkPriceFeedLusd), // price feed address
             3650 days // price feed staleness threshold in seconds
         );
 

--- a/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
@@ -53,6 +53,9 @@ contract Deploy001_Diamond_Dollar is Deploy001_Diamond_Dollar_Development {
         // start sending admin transactions
         vm.startBroadcast(adminPrivateKey);
 
+        // set threshold to 1 day
+        CHAINLINK_PRICE_FEED_THRESHOLD = 1 days;
+
         // init LUSD/USD chainlink price feed
         chainLinkPriceFeedLusd = AggregatorV3Interface(
             chainlinkPriceFeedAddress
@@ -66,7 +69,7 @@ contract Deploy001_Diamond_Dollar is Deploy001_Diamond_Dollar_Development {
         ubiquityPoolFacet.setCollateralChainLinkPriceFeed(
             collateralTokenAddress, // collateral token address
             address(chainLinkPriceFeedLusd), // price feed address
-            1 days // price feed staleness threshold in seconds
+            CHAINLINK_PRICE_FEED_THRESHOLD // price feed staleness threshold in seconds
         );
 
         // fetch latest prices from chainlink for collateral with index 0

--- a/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
@@ -1,13 +1,109 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {AggregatorV3Interface} from "@chainlink/interfaces/AggregatorV3Interface.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {Deploy001_Diamond_Dollar as Deploy001_Diamond_Dollar_Development} from "../development/Deploy001_Diamond_Dollar.s.sol";
+import {TWAPOracleDollar3poolFacet} from "../../src/dollar/facets/TWAPOracleDollar3poolFacet.sol";
+import {UbiquityPoolFacet} from "../../src/dollar/facets/UbiquityPoolFacet.sol";
+import {IMetaPool} from "../../src/dollar/interfaces/IMetaPool.sol";
 
 /// @notice Migration contract
 contract Deploy001_Diamond_Dollar is Deploy001_Diamond_Dollar_Development {
     function run() public override {
         // Run migration for testnet because "Deploy001_Diamond_Dollar" migration
-        // is identical both for development and mainnet
+        // is identical both for testnet/development and mainnet
         super.run();
+    }
+
+    /**
+     * @notice Initializes oracle related contracts
+     *
+     * @dev We override `initOracles()` from `Deploy001_Diamond_Dollar_Development` because
+     * we need to use already deployed contracts while `Deploy001_Diamond_Dollar_Development`
+     * deploys all oracle related contracts from scratch for ease of debugging.
+     *
+     * @dev Ubiquity protocol supports 2 oracles:
+     * 1. Curve's Dollar-3CRVLP metapool to fetch Dollar prices
+     * 2. Chainlink's price feed (used in UbiquityPool) to fetch collateral token prices in USD
+     *
+     * There are 2 migrations (deployment scripts):
+     * 1. Development (for usage in testnet and local anvil instance forked from mainnet)
+     * 2. Mainnet (for production usage in mainnet)
+     *
+     * Mainnet (i.e. production) migration uses already deployed contracts for:
+     * - Chainlink price feed contract
+     * - 3CRVLP ERC20 token
+     * - Curve's Dollar-3CRVLP metapool contract
+     */
+    function initOracles() public override {
+        // read env variables
+        address chainlinkPriceFeedAddress = vm.envAddress(
+            "COLLATERAL_TOKEN_CHAINLINK_PRICE_FEED_ADDRESS"
+        );
+        address token3CrvAddress = vm.envAddress("TOKEN_3CRV_ADDRESS");
+        address curveDollarMetapoolAddress = vm.envAddress(
+            "CURVE_DOLLAR_METAPOOL_ADDRESS"
+        );
+
+        //=======================================
+        // Chainlink LUSD/USD price feed setup
+        //=======================================
+
+        // start sending admin transactions
+        vm.startBroadcast(adminPrivateKey);
+
+        // init LUSD/USD chainlink price feed
+        chainLinkPriceFeedLusdUsd = AggregatorV3Interface(
+            chainlinkPriceFeedAddress
+        );
+
+        UbiquityPoolFacet ubiquityPoolFacet = UbiquityPoolFacet(
+            address(diamond)
+        );
+
+        // set price feed
+        ubiquityPoolFacet.setCollateralChainLinkPriceFeed(
+            collateralTokenAddress, // collateral token address
+            address(chainLinkPriceFeedLusdUsd), // price feed address
+            1 days // price feed staleness threshold in seconds
+        );
+
+        // fetch latest prices from chainlink for collateral with index 0
+        ubiquityPoolFacet.updateChainLinkCollateralPrice(0);
+
+        // stop sending admin transactions
+        vm.stopBroadcast();
+
+        //========================================
+        // Curve's Dollar-3CRVLP metapool setup
+        //========================================
+
+        // start sending owner transactions
+        vm.startBroadcast(ownerPrivateKey);
+
+        // init 3CRV token
+        curveTriPoolLpToken = IERC20(token3CrvAddress);
+
+        // init Dollar-3CRVLP Curve metapool
+        curveDollarMetaPool = IMetaPool(curveDollarMetapoolAddress);
+
+        /*
+        TODO: uncomment when we redeploy Curve's Dollar-3CRV metapool with the new Dollar token
+
+        TWAPOracleDollar3poolFacet twapOracleDollar3PoolFacet = TWAPOracleDollar3poolFacet(address(diamond));
+
+        // set Curve Dollar-3CRVLP pool in the diamond storage
+        twapOracleDollar3PoolFacet.setPool(
+            address(curveDollarMetaPool),
+            address(curveTriPoolLpToken)
+        );
+
+        // fetch latest Dollar price from Curve's Dollar-3CRVLP metapool
+        twapOracleDollar3PoolFacet.update();
+        */
+
+        // stop sending owner transactions
+        vm.stopBroadcast();
     }
 }

--- a/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
@@ -54,7 +54,7 @@ contract Deploy001_Diamond_Dollar is Deploy001_Diamond_Dollar_Development {
         vm.startBroadcast(adminPrivateKey);
 
         // init LUSD/USD chainlink price feed
-        chainLinkPriceFeedLusdUsd = AggregatorV3Interface(
+        chainLinkPriceFeedLusd = AggregatorV3Interface(
             chainlinkPriceFeedAddress
         );
 
@@ -65,7 +65,7 @@ contract Deploy001_Diamond_Dollar is Deploy001_Diamond_Dollar_Development {
         // set price feed
         ubiquityPoolFacet.setCollateralChainLinkPriceFeed(
             collateralTokenAddress, // collateral token address
-            address(chainLinkPriceFeedLusdUsd), // price feed address
+            address(chainLinkPriceFeedLusd), // price feed address
             1 days // price feed staleness threshold in seconds
         );
 

--- a/packages/contracts/src/dollar/interfaces/IMetaPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IMetaPool.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.19;
 
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
 /**
  * @notice Curve MetaPool interface
  *
@@ -17,23 +19,7 @@ pragma solidity 0.8.19;
  * 1. User sends 100 Dollar3CRV LP tokens to the pool
  * 2. User gets 100 Dollar/DAI/USDC/USDT (may choose any) tokens
  */
-interface IMetaPool {
-    /**
-     * @notice Transfers LP tokens to the `_to` address
-     * @param _to Address where to transfer LP tokens
-     * @param _value Amount of tokens to transfer
-     * @return Whether transfer is successful
-     */
-    function transfer(address _to, uint256 _value) external returns (bool);
-
-    /**
-     * @notice Approves `_spender` to spend `_value` amount on hehalf of the `msg.sender`
-     * @param _spender Spender address
-     * @param _value Amount
-     * @return Whether approve is successful
-     */
-    function approve(address _spender, uint256 _value) external returns (bool);
-
+interface IMetaPool is IERC20 {
     /**
      * @notice Calculates the current effective TWAP balances given two
      * snapshots over time, and the time elapsed between the two snapshots
@@ -192,24 +178,4 @@ interface IMetaPool {
      * @return Latest update timestamp
      */
     function block_timestamp_last() external view returns (uint256);
-
-    /**
-     * @notice Returns the balance of LP tokens for the `arg0` address
-     * @param arg0 Address to check the balance for
-     * @return LP balance
-     */
-    function balanceOf(address arg0) external view returns (uint256);
-
-    /**
-     * @notice Returns the remaining number of tokens that `spender` will be allowed
-     * to spend on behalf of `owner` through `transferFrom()`. This is zero by default.
-     * @dev This value changes when `approve()` or `transferFrom()` are called.
-     * @param owner Owner address
-     * @param spender Spender address
-     * @return Allowance amount
-     */
-    function allowance(
-        address owner,
-        address spender
-    ) external view returns (uint256);
 }

--- a/packages/contracts/src/dollar/mocks/MockMetaPool.sol
+++ b/packages/contracts/src/dollar/mocks/MockMetaPool.sol
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {IMetaPool} from "../interfaces/IMetaPool.sol";
 import {MockERC20} from "./MockERC20.sol";
 
-contract MockMetaPool is MockERC20 {
+contract MockMetaPool is IMetaPool, MockERC20 {
     address token0;
     address token1;
     address[2] public coins;
@@ -84,5 +85,42 @@ contract MockMetaPool is MockERC20 {
         bool /* _is_deposit */
     ) external pure returns (uint256) {
         return _amounts[0] > _amounts[1] ? _amounts[0] : _amounts[1];
+    }
+
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 min_dy
+    ) external returns (uint256) {
+        return 0;
+    }
+
+    function fee() external view returns (uint256) {
+        return 0;
+    }
+
+    function get_dy(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256) {
+        return 0;
+    }
+
+    function get_dy_underlying(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256) {
+        return 0;
+    }
+
+    function remove_liquidity_one_coin(
+        uint256 _burn_amount,
+        int128 i,
+        uint256 _min_received
+    ) external returns (uint256) {
+        return 0;
     }
 }

--- a/packages/contracts/src/dollar/mocks/MockMetaPool.sol
+++ b/packages/contracts/src/dollar/mocks/MockMetaPool.sol
@@ -88,39 +88,39 @@ contract MockMetaPool is IMetaPool, MockERC20 {
     }
 
     function exchange(
-        int128 i,
-        int128 j,
-        uint256 dx,
-        uint256 min_dy
-    ) external returns (uint256) {
+        int128 /* i */,
+        int128 /* j */,
+        uint256 /* dx */,
+        uint256 /* min_dy */
+    ) external pure returns (uint256) {
         return 0;
     }
 
-    function fee() external view returns (uint256) {
+    function fee() external pure returns (uint256) {
         return 0;
     }
 
     function get_dy(
-        int128 i,
-        int128 j,
-        uint256 dx
-    ) external view returns (uint256) {
+        int128 /* i */,
+        int128 /* j */,
+        uint256 /* dx */
+    ) external pure returns (uint256) {
         return 0;
     }
 
     function get_dy_underlying(
-        int128 i,
-        int128 j,
-        uint256 dx
-    ) external view returns (uint256) {
+        int128 /* i */,
+        int128 /* j */,
+        uint256 /* dx */
+    ) external pure returns (uint256) {
         return 0;
     }
 
     function remove_liquidity_one_coin(
-        uint256 _burn_amount,
-        int128 i,
-        uint256 _min_received
-    ) external returns (uint256) {
+        uint256 /* _burn_amount */,
+        int128 /* i */,
+        uint256 /* _min_received */
+    ) external pure returns (uint256) {
         return 0;
     }
 }


### PR DESCRIPTION
This PR updates migration scripts to deploy oracle related contracts.

We've got the following oracle related contracts:
1. Curve Dollar-3CRVLP metapool (to fetch Dollar price)
2. Chainlink price feed (to fetch collateral token price in [UbiquityPool](https://github.com/ubiquity/ubiquity-dollar/blob/dae4cd3c5c29abaae8792e2461c23604a8fedff7/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol))

Development migration deploys all oracle related contracts from scratch for ease of debugging.

Mainnet migration uses already deployed oracle related contracts.

The only catch is that we haven't yet redeployed the old Dollar-3CRVLP [metapool](https://etherscan.io/address/0x20955CB69Ae1515962177D164dfC9522feef567E) because we need the new `Dollar` token contract to be redeployed hence this [commented block](https://github.com/ubiquity/ubiquity-dollar/pull/855/files#diff-9abf61ecfaca25a4d90a25c4c65cc6effba1882585bd85923ec04689f4254551R92-R104). 