### PR TITLE
feat: add getRedeemCollateralBalance() method

### DIFF
--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -69,6 +69,18 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
         return LibUbiquityPool.getDollarPriceUsd();
     }
 
+    /// @inheritdoc IUbiquityPool
+    function getRedeemCollateralBalance(
+        address userAddress,
+        uint256 collateralIndex
+    ) external view returns (uint256) {
+        return
+            LibUbiquityPool.getRedeemCollateralBalance(
+                userAddress,
+                collateralIndex
+            );
+    }
+
     //====================
     // Public functions
     //====================

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -67,6 +67,17 @@ interface IUbiquityPool {
      */
     function getDollarPriceUsd() external view returns (uint256 dollarPriceUsd);
 
+    /**
+     * @notice Returns user's balance available for redemption
+     * @param userAddress User address
+     * @param collateralIndex Collateral token index
+     * @return User's balance available for redemption
+     */
+    function getRedeemCollateralBalance(
+        address userAddress,
+        uint256 collateralIndex
+    ) external view returns (uint256);
+
     //====================
     // Public functions
     //====================

--- a/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
+++ b/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
@@ -310,6 +310,21 @@ library LibUbiquityPool {
             .div(1e18);
     }
 
+    /**
+     * @notice Returns user's balance available for redemption
+     * @param userAddress User address
+     * @param collateralIndex Collateral token index
+     * @return User's balance available for redemption
+     */
+    function getRedeemCollateralBalance(
+        address userAddress,
+        uint256 collateralIndex
+    ) internal view returns (uint256) {
+        UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
+        return
+            poolStorage.redeemCollateralBalances[userAddress][collateralIndex];
+    }
+
     //====================
     // Public functions
     //====================
@@ -533,10 +548,9 @@ library LibUbiquityPool {
             // roundId
             int256 answer, // startedAt
             ,
-            uint256 updatedAt,
+            uint256 updatedAt, // answeredInRound
 
-        ) = // answeredInRound
-            priceFeed.latestRoundData();
+        ) = priceFeed.latestRoundData();
 
         // fetch number of decimals in chainlink feed
         uint256 priceFeedDecimals = priceFeed.decimals();

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -268,6 +268,37 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         assertEq(dollarPriceUsd, 1_000_000);
     }
 
+    function testGetRedeemCollateralBalance_ShouldReturnRedeemCollateralBalance()
+        public
+    {
+        vm.prank(admin);
+        ubiquityPoolFacet.setPriceThresholds(
+            1000000, // mint threshold
+            1000000 // redeem threshold
+        );
+
+        // user sends 100 collateral tokens and gets 99 Dollars (-1% mint fee)
+        vm.prank(user);
+        ubiquityPoolFacet.mintDollar(
+            0, // collateral index
+            100e18, // Dollar amount
+            99e18, // min amount of Dollars to mint
+            100e18 // max collateral to send
+        );
+
+        // user redeems 99 Dollars for 97.02 (accounts for 2% redemption fee) collateral tokens
+        vm.prank(user);
+        ubiquityPoolFacet.redeemDollar(
+            0, // collateral index
+            99e18, // Dollar amount
+            90e18 // min collateral out
+        );
+
+        uint256 redeemCollateralBalance = ubiquityPoolFacet
+            .getRedeemCollateralBalance(user, 0);
+        assertEq(redeemCollateralBalance, 97.02e18);
+    }
+
     //====================
     // Public functions
     //====================


### PR DESCRIPTION
This PR adds a new view method for [redeemCollateralBalances](https://github.com/ubiquity/ubiquity-dollar/blob/8fa47c9414aa134c9652cc0d543bdfeb719b3e99/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol#L69C85-L69C109) required for ubiquity pool UI.

This PR is opened towards the `fix-review` (i.e. sherlock fix) branch because sherlock team accepted this change but we need to show the current PR to our lead senior watson when we implement all of the fixes from [here](https://github.com/ubiquity/ubiquity-dollar/issues/866).

P.S. All `Check For Diamond Storage Changes` workflow runs are failing again with API rate limit error