### PR TITLE
chore: limit diamond storage check API calls

### DIFF
--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -24,10 +24,24 @@ jobs:
         with:
           version: nightly
 
-      - id: set-matrix
+      - name: Narrow down test matrix scope to changed Dollar libraries to limit API requests
+        id: changed-libraries
+        uses: tj-actions/changed-files@v42
+        with:
+          files_yaml: |
+            libraries:
+              - packages/contracts/src/dollar/libraries/Lib*.sol
+
+      - name: Set contracts matrix
+        id: set-matrix
         working-directory: packages/contracts
+        if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
+        env:
+          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
         run: |
-          forge tree | grep -E '^src/dollar/libraries/Lib' | cut -d' ' -f1 | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          for DIAMOND_LIB in "$CHANGED_LIBS"; do
+            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          done
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
     outputs:


### PR DESCRIPTION
Narrow down test matrix scope to changed Dollar libraries

Resolves: #876

QA: Changed 5 files in a dummy PR, 3 files are libraries with storage, only those were picked up to be analyzed.

https://github.com/gitcoindev/ubiquity-dollar/pull/15/files#diff-3c2e3163820394bdd79dac50e9c8f83d7938e2f0b8354d5214b04b4798b114f8

GitHub diamond storage check action triggered only on 3 libraries:

https://github.com/gitcoindev/ubiquity-dollar/actions/runs/7638730341

After this pull request is accepted and merged, https://github.com/ubiquity/ubiquity-dollar/pull/878 can be reverted.

