### PR TITLE
Feat limit api requests core contracts check and graphql only on push to development branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,8 @@ name: CodeQL Analysis
 on:
   pull_request:
   push:
+   branches:
+     - development
 
 jobs:
   code-ql-analysis:

--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -20,10 +20,24 @@ jobs:
         with:
           version: nightly
 
-      - id: set-matrix
+      - name: Narrow down test matrix scope to changed contracts to limit API requests
+        id: changed-contracts
+        uses: tj-actions/changed-files@v42
+        with:
+          files_yaml: |
+            contracts:
+              - packages/contracts/src/dollar/core/*.sol
+
+      - name: Set contracts matrix
+        id: set-matrix
         working-directory: packages/contracts
+        if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
+        env:
+          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
         run: |
-          forge tree | grep -E '^src/dollar/core' | cut -d' ' -f1 | xargs basename -s | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          for CONTRACT in "$CHANGED_CONTRACTS"; do
+            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          done
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
     outputs:


### PR DESCRIPTION
Resolves #886 

* similar solution as for diamond libraries
* also reduces GraphQL analysis on CI to pull requests and pushes to `development` branch only

QA: https://github.com/gitcoindev/ubiquity-dollar/actions/runs/7640624026/job/20816126150?pr=19


