### PR TITLE
Update block count in a week

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -120,6 +120,7 @@
     "rpcutil",
     "rustup",
     "Sablier",
+    "sepolia",
     "setu",
     "Shouldset",
     "Sighash",

--- a/packages/contracts/scripts/shared/constants/networks.ts
+++ b/packages/contracts/scripts/shared/constants/networks.ts
@@ -2,6 +2,7 @@ export const Networks: Record<string, number> = {
   mainnet: 1,
   optimism: 10,
   goerli: 5,
+  sepolia: 11155111,
 };
 
 export const FALLBACK_RPC = "https://eth.ubq.fi/v1/mainnet";

--- a/packages/contracts/scripts/task/README.md
+++ b/packages/contracts/scripts/task/README.md
@@ -1,0 +1,23 @@
+# Dollar task scripts
+
+## BlocksInWeek
+
+BlocksInWeek task provides a close approximate of number of blocks mined in one week.
+
+Usage:
+
+Ethereum mainnet:
+
+```
+npx tsx scripts/task/task.ts BlocksInWeek --network=mainnet
+```
+
+Sepolia:
+
+Ethereum mainnet:
+
+```
+npx tsx scripts/task/task.ts BlocksInWeek --network=sepolia
+```
+
+Prerequisite: set ETHERSCAN_API_KEY in .env

--- a/packages/contracts/scripts/task/dollar/blocks-in-week.ts
+++ b/packages/contracts/scripts/task/dollar/blocks-in-week.ts
@@ -1,0 +1,51 @@
+import { OptionDefinition } from "command-line-args";
+
+import { Networks, TaskFuncParam } from "../../shared";
+import { EtherscanProvider } from "ethers";
+
+export const optionDefinitions: OptionDefinition[] = [
+  { name: "task", defaultOption: true },
+  { name: "network", alias: "n", type: String },
+];
+
+const func = async (params: TaskFuncParam) => {
+  const { args, env } = params;
+  const { network } = args;
+
+  const chainId = Networks[network] ?? undefined;
+  if (!chainId) {
+    throw new Error(`Unsupported network: ${network} Please configure it out first`);
+  }
+
+  const provider = new EtherscanProvider(chainId, env.etherscanApiKey);
+
+  console.log(`Calculating number of blocks in the last week...`);
+  const secondsInAWeek = 604800; // 24 * 7 * 60 * 60 seconds is one week
+  const currentBlockNumber = await provider.getBlockNumber();
+  const currentBlockTimestamp = (await provider.getBlock(currentBlockNumber))?.timestamp;
+  const blockTimestampTwoBlocksAgo = (await provider.getBlock(currentBlockNumber - 2))?.timestamp;
+
+  if (currentBlockTimestamp && blockTimestampTwoBlocksAgo) {
+    const avgBlockTime = (currentBlockTimestamp - blockTimestampTwoBlocksAgo) / 2;
+    console.log(`Recent average block time: ${avgBlockTime} seconds`);
+
+    const oneWeekAgo = currentBlockTimestamp - secondsInAWeek;
+    const estimatedBlocksInAWeek = secondsInAWeek / avgBlockTime;
+    console.log(`Estimated blocks in a week best case ${estimatedBlocksInAWeek}`);
+
+    let estimatedBlockNumber = currentBlockNumber - estimatedBlocksInAWeek;
+    let estimatedBlockTimestamp = (await provider.getBlock(estimatedBlockNumber))?.timestamp;
+
+    if (estimatedBlockTimestamp) {
+      let deltaBlockTime = oneWeekAgo - estimatedBlockTimestamp;
+      estimatedBlockNumber += Math.trunc(deltaBlockTime / avgBlockTime);
+      estimatedBlockTimestamp = (await provider.getBlock(estimatedBlockNumber))?.timestamp || estimatedBlockTimestamp;
+      deltaBlockTime -= estimatedBlockTimestamp - oneWeekAgo;
+
+      console.log(`Produced ${estimatedBlocksInAWeek - deltaBlockTime / avgBlockTime} blocks, ${deltaBlockTime / avgBlockTime} worst than the best case`);
+    }
+  }
+
+  return "succeeded";
+};
+export default func;

--- a/packages/contracts/scripts/task/dollar/blocks-in-week.ts
+++ b/packages/contracts/scripts/task/dollar/blocks-in-week.ts
@@ -8,7 +8,7 @@ export const optionDefinitions: OptionDefinition[] = [
   { name: "network", alias: "n", type: String },
 ];
 
-const func = async (params: TaskFuncParam) => {
+const funcBlocksInAWeek = async (params: TaskFuncParam) => {
   const { args, env } = params;
   const { network } = args;
 
@@ -48,4 +48,4 @@ const func = async (params: TaskFuncParam) => {
 
   return "succeeded";
 };
-export default func;
+export default funcBlocksInAWeek;

--- a/packages/contracts/scripts/task/manager.ts
+++ b/packages/contracts/scripts/task/manager.ts
@@ -2,11 +2,16 @@ import { OptionDefinition } from "command-line-args";
 
 import { TaskFuncCallBack } from "../shared";
 
-import PriceResetHandler, { optionDefinitions as priceResetOptions } from "./dollar/priceReset";
+import PriceResetHandler, { optionDefinitions, optionDefinitions as priceResetOptions } from "./dollar/price-reset";
+import BlocksInWeekHandler from "./dollar/blocks-in-week";
 
 export const TASK_FUNCS: Record<string, { handler: TaskFuncCallBack; options: OptionDefinition[] }> = {
   PriceReset: {
     handler: PriceResetHandler,
     options: priceResetOptions,
+  },
+  BlocksInWeek: {
+    handler: BlocksInWeekHandler,
+    options: optionDefinitions,
   },
 };

--- a/packages/contracts/scripts/task/task.ts
+++ b/packages/contracts/scripts/task/task.ts
@@ -11,7 +11,7 @@ const main = async () => {
     throw new Error("You MUST put the task name in command arguments at least");
   }
 
-  const envPath = path.join(__dirname, "../.env");
+  const envPath = path.join(__dirname, "../../.env");
   if (!fs.existsSync(envPath)) {
     throw new Error("Env file not found");
   }
@@ -26,6 +26,7 @@ const main = async () => {
   let args;
   try {
     args = CommandLineArgs(commandLineParseOptions);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     console.error(`Argument parse failed!, error: ${error}`);
     return;

--- a/packages/contracts/src/dollar/libraries/LibStaking.sol
+++ b/packages/contracts/src/dollar/libraries/LibStaking.sol
@@ -267,8 +267,8 @@ library LibStaking {
         // deposit new shares
         LibChef.deposit(msg.sender, _sharesAmount, _id);
         // calculate end locking period block number
-        // 1 week = 45361 blocks = 2371753*7/366
-        // n = (block + duration * 45361)
+        // 1 week = 49930 blocks
+        // n = (block number + duration * 49930)
         stake.endBlock = block.number + _weeks * ss.blockCountInAWeek;
 
         // should be done after masterchef withdraw

--- a/packages/contracts/src/dollar/upgradeInitializers/DiamondInit.sol
+++ b/packages/contracts/src/dollar/upgradeInitializers/DiamondInit.sol
@@ -71,7 +71,7 @@ contract DiamondInit is Modifiers {
         // staking
         LibStaking.StakingData storage ls = LibStaking.stakingStorage();
         ls.stakingDiscountMultiplier = uint256(0.001 ether); // 0.001
-        ls.blockCountInAWeek = 45361;
+        ls.blockCountInAWeek = 49930;
 
         // reentrancy guard
         _initReentrancyGuard();

--- a/packages/contracts/test/diamond/facets/ChefFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ChefFacet.t.sol
@@ -311,7 +311,7 @@ contract DepositStateChefTest is DepositStateChef {
 
         // advance the block number to  staking time so the withdraw is possible
         uint256 currentBlock = block.number;
-        blocks = bound(blocks, 45361, 2 ** 128 - 1);
+        blocks = bound(blocks, 49930, 2 ** 128 - 1);
         assertEq(chefFacet.totalShares(), shares);
 
         uint256 preBal = governanceToken.balanceOf(fourthAccount);

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -312,7 +312,7 @@ contract DepositStateTest is DepositStateStaking {
 
         // advance the block number to  staking time so the withdraw is possible
         uint256 currentBlock = block.number;
-        blocks = bound(blocks, 45361, 2 ** 128 - 1);
+        blocks = bound(blocks, 49930, 2 ** 128 - 1);
         assertEq(chefFacet.totalShares(), shares);
 
         uint256 preBal = governanceToken.balanceOf(fourthAccount);


### PR DESCRIPTION
Resolves https://github.com/sherlock-audit/2023-12-ubiquity-judging/issues/230

Measured approximate number of blocks:

```
npx tsx scripts/task/task.ts BlocksInWeek --network=mainnet
...
Calculating number of blocks in the last week...
Recent average block time: 12 seconds
Estimated blocks in a week best case 50400
Produced 49930 blocks, 470 worst than the best case
```

QA: `Ran 33 test suites: 341 tests passed, 0 failed, 0 skipped (341 total tests)`

