### PR TITLE
feat: protect protocol upgradeability loss

### DIFF
--- a/packages/contracts/src/dollar/libraries/LibDiamond.sol
+++ b/packages/contracts/src/dollar/libraries/LibDiamond.sol
@@ -321,7 +321,8 @@ library LibDiamond {
             _facetAddress != address(0),
             "LibDiamondCut: Can't remove function that doesn't exist"
         );
-        // precomputed bytes4(keccak256()) diamondCut function selector 0x1f931c1c to save gas
+        // precomputed diamondCut function selector to save gas
+        // bytes4(keccak256(abi.encodeWithSignature("diamondCut((address,uint8,bytes4[])[],address,bytes)"))) == 0x1f931c1c
         require(
             _selector != bytes4(0x1f931c1c),
             "LibDiamondCut: Can't remove diamondCut function"

--- a/packages/contracts/src/dollar/libraries/LibDiamond.sol
+++ b/packages/contracts/src/dollar/libraries/LibDiamond.sol
@@ -321,6 +321,11 @@ library LibDiamond {
             _facetAddress != address(0),
             "LibDiamondCut: Can't remove function that doesn't exist"
         );
+        // precomputed bytes4(keccak256()) diamondCut function selector 0x1f931c1c to save gas
+        require(
+            _selector != bytes4(0x1f931c1c),
+            "LibDiamondCut: Can't remove diamondCut function"
+        );
         // an immutable function is a function defined directly in a diamond
         require(
             _facetAddress != address(this),

--- a/packages/contracts/test/diamond/DiamondTest.t.sol
+++ b/packages/contracts/test/diamond/DiamondTest.t.sol
@@ -287,6 +287,23 @@ contract TestDiamond is DiamondTestSetup {
         IMockFacet(address(diamondCutFacet)).functionB();
     }
 
+    function testCutFacetShouldNotRemoveDiamondCutFunction() public {
+        FacetCut[] memory facetCut = new FacetCut[](1);
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = diamondCutFacet.diamondCut.selector;
+
+        facetCut[0] = FacetCut({
+            facetAddress: address(0),
+            action: FacetCutAction.Remove,
+            functionSelectors: selectors
+        });
+
+        // try to remove diamondCut function
+        vm.prank(owner);
+        vm.expectRevert("LibDiamondCut: Can't remove diamondCut function");
+        diamondCutFacet.diamondCut(facetCut, address(0x0), "");
+    }
+
     function testSelectors_ShouldBeAssociatedWithCorrectFacet() public {
         for (uint256 i; i < facetAddressList.length; i++) {
             if (compareStrings(facetNames[i], "DiamondCutFacet")) {


### PR DESCRIPTION
diamondCut function cannot be removed.

Resolves: https://github.com/sherlock-audit/2023-12-ubiquity-judging/issues/21
