### PR TITLE
fix: use msg.sender on Ubiquistick NFT mint

### DIFF
--- a/packages/contracts/src/dollar/libraries/LibBondingCurve.sol
+++ b/packages/contracts/src/dollar/libraries/LibBondingCurve.sol
@@ -130,7 +130,7 @@ library LibBondingCurve {
         }
 
         IERC20 dollar = IERC20(LibAppStorage.appStorage().dollarTokenAddress);
-        dollar.transferFrom(_recipient, address(this), _collateralDeposited);
+        dollar.transferFrom(msg.sender, address(this), _collateralDeposited);
 
         ss.poolBalance = ss.poolBalance + _collateralDeposited;
         ss.share[_recipient] += tokensReturned;


### PR DESCRIPTION
Resolves https://github.com/sherlock-audit/2023-12-ubiquity-judging/issues/156 (part of https://github.com/ubiquity/ubiquity-dollar/issues/874)