### PR TITLE
ci: use deploy artifact name

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,4 +48,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: static
-          path: static
+          path: packages/dapp/dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
           production_branch: ${{ github.event.repository.default_branch }}
+          build_artifact_name: "static"
           output_directory: "static"
           current_branch: ${{ github.event.workflow_run.head_branch }}
           cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -8,7 +8,7 @@
     "prebuild": "run-p clean",
     "build": "run-s build:types build:next build:export",
     "build:watch": "run-s build:types build:next",
-    "build:export": "next export --outdir ../../static",
+    "build:export": "next export --outdir dist",
     "start": "next dev",
     "clean": "rimraf next types node_modules",
     "build:next": "next build",


### PR DESCRIPTION
This PR uses build artifact name required for https://github.com/ubiquity/cloudflare-deploy-action