### PR TITLE
fix: set last byte to 0 in lib storages

### DIFF
--- a/packages/contracts/src/dollar/libraries/LibAccessControl.sol
+++ b/packages/contracts/src/dollar/libraries/LibAccessControl.sol
@@ -17,7 +17,7 @@ library LibAccessControl {
     bytes32 constant ACCESS_CONTROL_STORAGE_SLOT =
         bytes32(
             uint256(keccak256("ubiquity.contracts.access.control.storage")) - 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /// @notice Structure to keep all role members with their admin role
     struct RoleData {

--- a/packages/contracts/src/dollar/libraries/LibBondingCurve.sol
+++ b/packages/contracts/src/dollar/libraries/LibBondingCurve.sol
@@ -23,7 +23,8 @@ library LibBondingCurve {
 
     /// @notice Storage slot used to store data for this library
     bytes32 constant BONDING_CONTROL_STORAGE_SLOT =
-        bytes32(uint256(keccak256("ubiquity.contracts.bonding.storage")) - 1);
+        bytes32(uint256(keccak256("ubiquity.contracts.bonding.storage")) - 1) &
+            ~bytes32(uint256(0xff));
 
     /// @notice Emitted when collateral is deposited
     event Deposit(address indexed user, uint256 amount);

--- a/packages/contracts/src/dollar/libraries/LibChef.sol
+++ b/packages/contracts/src/dollar/libraries/LibChef.sol
@@ -59,7 +59,7 @@ library LibChef {
     bytes32 constant UBIQUITY_CHEF_STORAGE_POSITION =
         bytes32(
             uint256(keccak256("diamond.standard.ubiquity.chef.storage")) - 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /**
      * @notice Returns struct used as a storage for this library

--- a/packages/contracts/src/dollar/libraries/LibCollectableDust.sol
+++ b/packages/contracts/src/dollar/libraries/LibCollectableDust.sol
@@ -36,7 +36,7 @@ library LibCollectableDust {
         bytes32(
             uint256(keccak256("ubiquity.contracts.collectable.dust.storage")) -
                 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /**
      * @notice Returns struct used as a storage for this library

--- a/packages/contracts/src/dollar/libraries/LibCreditClock.sol
+++ b/packages/contracts/src/dollar/libraries/LibCreditClock.sol
@@ -22,7 +22,7 @@ library LibCreditClock {
     bytes32 constant CREDIT_CLOCK_STORAGE_POSITION =
         bytes32(
             uint256(keccak256("ubiquity.contracts.credit.clock.storage")) - 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /// @notice Struct used as a storage for the current library
     struct CreditClockData {

--- a/packages/contracts/src/dollar/libraries/LibCreditNftManager.sol
+++ b/packages/contracts/src/dollar/libraries/LibCreditNftManager.sol
@@ -31,7 +31,7 @@ library LibCreditNftManager {
             uint256(
                 keccak256("ubiquity.contracts.credit.nft.manager.storage")
             ) - 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /// @notice Emitted when Credit NFT to Governance conversion rate was updated
     event ExpiredCreditNftConversionRateChanged(

--- a/packages/contracts/src/dollar/libraries/LibCreditRedemptionCalculator.sol
+++ b/packages/contracts/src/dollar/libraries/LibCreditRedemptionCalculator.sol
@@ -39,7 +39,7 @@ library LibCreditRedemptionCalculator {
                     "ubiquity.contracts.credit.redemption.calculator.storage"
                 )
             ) - 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /**
      * @notice Sets the `p` param in the Credit mint calculation formula:

--- a/packages/contracts/src/dollar/libraries/LibCurveDollarIncentive.sol
+++ b/packages/contracts/src/dollar/libraries/LibCurveDollarIncentive.sol
@@ -20,7 +20,8 @@ library LibCurveDollarIncentive {
 
     /// @notice Storage slot used to store data for this library
     bytes32 constant CURVE_DOLLAR_STORAGE_SLOT =
-        bytes32(uint256(keccak256("ubiquity.contracts.curve.storage")) - 1);
+        bytes32(uint256(keccak256("ubiquity.contracts.curve.storage")) - 1) &
+            ~bytes32(uint256(0xff));
 
     /// @notice One point in `bytes16`
     bytes16 constant _one = bytes16(abi.encodePacked(uint256(1 ether)));

--- a/packages/contracts/src/dollar/libraries/LibDiamond.sol
+++ b/packages/contracts/src/dollar/libraries/LibDiamond.sol
@@ -20,7 +20,8 @@ error InitializationFunctionReverted(
 library LibDiamond {
     /// @notice Storage slot used to store data for this library
     bytes32 constant DIAMOND_STORAGE_POSITION =
-        bytes32(uint256(keccak256("diamond.standard.diamond.storage")) - 1);
+        bytes32(uint256(keccak256("diamond.standard.diamond.storage")) - 1) &
+            ~bytes32(uint256(0xff));
 
     /// @notice Struct used as a mapping of facet to function selector position
     struct FacetAddressAndPosition {

--- a/packages/contracts/src/dollar/libraries/LibDirectGovernanceFarmer.sol
+++ b/packages/contracts/src/dollar/libraries/LibDirectGovernanceFarmer.sol
@@ -53,7 +53,7 @@ library LibDirectGovernanceFarmer {
         bytes32(
             uint256(keccak256("ubiquity.contracts.direct.governance.storage")) -
                 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /// @notice Struct used as a storage for the current library
     struct DirectGovernanceData {

--- a/packages/contracts/src/dollar/libraries/LibStaking.sol
+++ b/packages/contracts/src/dollar/libraries/LibStaking.sol
@@ -14,7 +14,8 @@ library LibStaking {
 
     /// @notice Storage slot used to store data for this library
     bytes32 constant STAKING_CONTROL_STORAGE_SLOT =
-        bytes32(uint256(keccak256("ubiquity.contracts.staking.storage")) - 1);
+        bytes32(uint256(keccak256("ubiquity.contracts.staking.storage")) - 1) &
+            ~bytes32(uint256(0xff));
 
     /// @notice Emitted when Dollar or 3CRV tokens are removed from Curve MetaPool
     event PriceReset(

--- a/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
+++ b/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
@@ -26,7 +26,7 @@ library LibUbiquityPool {
     bytes32 constant UBIQUITY_POOL_STORAGE_POSITION =
         bytes32(
             uint256(keccak256("ubiquity.contracts.ubiquity.pool.storage")) - 1
-        );
+        ) & ~bytes32(uint256(0xff));
 
     /// @notice Struct used as a storage for this library
     struct UbiquityPoolStorage {


### PR DESCRIPTION
Resolves https://github.com/sherlock-audit/2023-12-ubiquity-judging/issues/121 (part of https://github.com/ubiquity/ubiquity-dollar/issues/874)

Simply put this is gas optimization that sets the last byte of all storage slots to 0 which somehow optimizes gas usage (you may check https://eips.ethereum.org/EIPS/eip-7201).

I've double checked (on the off chance) all lib storage slots for collisions but everything seems to be fine.