### PR TITLE
refactor(migration): deploy collateral in testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ ADMIN_PRIVATE_KEY="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b7
 
 # Collateral token address (used in UbiquityPoolFacet, allows users to mint/redeem Dollars in exchange for collateral token).
 # By default set to LUSD address in ethereum mainnet.
-# - mainnet/anvil(forked from mainnet): 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0 (LUSD)
-# - testnet: 0x3e622317f8C93f7328350cF0B56d9eD4C620C5d6 (DAI)
-# NOTICE: LUSD token is not deployed to sepolia testnet so we use DAI instead which is deployed to testnet
+# - mainnet: 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0 (LUSD)
+# - testnet/anvil: deploys collateral ERC20 token from scratch
 COLLATERAL_TOKEN_ADDRESS="0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
 
 # Collateral token price feed address from chainlink.

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -5,9 +5,8 @@ ADMIN_PRIVATE_KEY="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b7
 
 # Collateral token address (used in UbiquityPoolFacet, allows users to mint/redeem Dollars in exchange for collateral token).
 # By default set to LUSD address in ethereum mainnet.
-# - mainnet/anvil(forked from mainnet): 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0 (LUSD)
-# - testnet: 0x3e622317f8C93f7328350cF0B56d9eD4C620C5d6 (DAI)
-# NOTICE: LUSD token is not deployed to sepolia testnet so we use DAI instead which is deployed to testnet
+# - mainnet: 0x5f98805A4E8be255a32880FDeC7F6728C6568bA0 (LUSD)
+# - testnet/anvil: deploys collateral ERC20 token from scratch
 COLLATERAL_TOKEN_ADDRESS="0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
 
 # Collateral token price feed address from chainlink.

--- a/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
@@ -97,7 +97,6 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
     // env variables
     uint256 adminPrivateKey;
     uint256 ownerPrivateKey;
-    address collateralTokenAddress;
 
     // threshold in seconds when price feed response should be considered stale
     uint256 CHAINLINK_PRICE_FEED_THRESHOLD;
@@ -123,6 +122,9 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
     IERC20 curveTriPoolLpToken; // Curve's 3CRV-LP token
     ICurveStableSwapMetaNG curveDollarMetaPool; // Curve's Dollar-3CRVLP metapool
 
+    // collateral ERC20 token used in UbiquityPoolFacet
+    IERC20 collateralToken;
+
     // selectors for all of the facets
     bytes4[] selectorsOfAccessControlFacet;
     bytes4[] selectorsOfDiamondCutFacet;
@@ -135,7 +137,6 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         // read env variables
         adminPrivateKey = vm.envUint("ADMIN_PRIVATE_KEY");
         ownerPrivateKey = vm.envUint("OWNER_PRIVATE_KEY");
-        collateralTokenAddress = vm.envAddress("COLLATERAL_TOKEN_ADDRESS");
 
         address adminAddress = vm.addr(adminPrivateKey);
         address ownerAddress = vm.addr(ownerPrivateKey);
@@ -265,6 +266,12 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         // stop sending admin transactions
         vm.stopBroadcast();
 
+        //==========================
+        // Collateral token setup
+        //==========================
+
+        initCollateral();
+
         //=========================
         // UbiquiPoolFacet setup
         //=========================
@@ -278,8 +285,9 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
 
         // add collateral token (users can mint/redeem Dollars in exchange for collateral)
         uint256 poolCeiling = 10_000e18; // max 10_000 of collateral tokens is allowed
+
         ubiquityPoolFacet.addCollateralToken(
-            collateralTokenAddress, // collateral token address
+            address(collateralToken), // collateral token address
             address(chainLinkPriceFeedLusd), // chainlink LUSD/USD price feed address
             poolCeiling // pool ceiling amount
         );
@@ -344,6 +352,26 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
     }
 
     /**
+     * @notice Initializes collateral token
+     *
+     * @dev Collateral token is different for mainnet and development:
+     * - mainnet: uses LUSD address from `COLLATERAL_TOKEN_ADDRESS` env variables
+     * - development: deploys mocked ERC20 token from scratch
+     */
+    function initCollateral() public virtual {
+        //=================================
+        // Collateral ERC20 token deploy
+        //=================================
+
+        // deploy ERC20 mock token for ease of debugging
+        collateralToken = new MockERC20(
+            "Collateral test token",
+            "CLT_TEST",
+            18
+        );
+    }
+
+    /**
      * @notice Initializes oracle related contracts
      *
      * @dev Ubiquity protocol supports 2 oracles:
@@ -398,7 +426,7 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
 
         // set price feed address and threshold in seconds
         ubiquityPoolFacet.setCollateralChainLinkPriceFeed(
-            collateralTokenAddress, // collateral token address
+            address(collateralToken), // collateral token address
             address(chainLinkPriceFeedLusd), // price feed address
             CHAINLINK_PRICE_FEED_THRESHOLD // price feed staleness threshold in seconds
         );

--- a/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/development/Deploy001_Diamond_Dollar.s.sol
@@ -270,7 +270,13 @@ contract Deploy001_Diamond_Dollar is Script, DiamondTestHelper {
         // Collateral token setup
         //==========================
 
+        // start sending owner transactions
+        vm.startBroadcast(ownerPrivateKey);
+
         initCollateral();
+
+        // stop sending owner transactions
+        vm.stopBroadcast();
 
         //=========================
         // UbiquiPoolFacet setup

--- a/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
+++ b/packages/contracts/migrations/mainnet/Deploy001_Diamond_Dollar.s.sol
@@ -17,6 +17,27 @@ contract Deploy001_Diamond_Dollar is Deploy001_Diamond_Dollar_Development {
     }
 
     /**
+     * @notice Initializes collateral token
+     *
+     * @dev Collateral token is different for mainnet and development:
+     * - mainnet: uses LUSD address from `COLLATERAL_TOKEN_ADDRESS` env variables
+     * - development: deploys mocked ERC20 token from scratch
+     */
+    function initCollateral() public override {
+        // read env variables
+        address collateralTokenAddress = vm.envAddress(
+            "COLLATERAL_TOKEN_ADDRESS"
+        );
+
+        //=================================
+        // Collateral ERC20 token setup
+        //=================================
+
+        // use existing LUSD contract for mainnet
+        collateralToken = IERC20(collateralTokenAddress);
+    }
+
+    /**
      * @notice Initializes oracle related contracts
      *
      * @dev We override `initOracles()` from `Deploy001_Diamond_Dollar_Development` because
@@ -67,7 +88,7 @@ contract Deploy001_Diamond_Dollar is Deploy001_Diamond_Dollar_Development {
 
         // set price feed
         ubiquityPoolFacet.setCollateralChainLinkPriceFeed(
-            collateralTokenAddress, // collateral token address
+            address(collateralToken), // collateral token address
             address(chainLinkPriceFeedLusd), // price feed address
             CHAINLINK_PRICE_FEED_THRESHOLD // price feed staleness threshold in seconds
         );

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -26,7 +26,7 @@
     "test:slither": "slither . --compile-force-framework foundry",
     "test:echidna": "echidna-test . --config echidna.config.yml",
     "test:coverage": "forge coverage",
-    "start:anvil": "anvil --fork-url https://eth.ubq.fi/v1/mainnet --chain-id 31337",
+    "start:anvil": "anvil --fork-url https://mainnet.gateway.tenderly.co --chain-id 31337",
     "prebuild": "run-p clean",
     "deploy:development": "migrations/development/deploy.sh",
     "deploy:mainnet": "migrations/mainnet/deploy.sh",

--- a/packages/contracts/src/dollar/mocks/MockERC20.sol
+++ b/packages/contracts/src/dollar/mocks/MockERC20.sol
@@ -4,11 +4,15 @@ pragma solidity 0.8.19;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {
+    uint8 internal __decimals;
+
     constructor(
         string memory _name,
         string memory _symbol,
         uint8 _decimals
-    ) ERC20(_name, _symbol) {}
+    ) ERC20(_name, _symbol) {
+        __decimals = _decimals;
+    }
 
     function mint(address to, uint256 value) public virtual {
         _mint(to, value);
@@ -16,5 +20,9 @@ contract MockERC20 is ERC20 {
 
     function burn(address from, uint256 value) public virtual {
         _burn(from, value);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return __decimals;
     }
 }


### PR DESCRIPTION
This PR refactors migration script:
- for mainnet we use `LUSD` collateral token (read its address from env variable)
- for testnet/anvil we deploy collateral token from scratch (for ease of debugging)