### PR TITLE
Feat/fractional pool

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -140,6 +140,7 @@
     "twap",
     "typechain",
     "TYPEHASH",
+    "Twocrypto",
     "Ubiqui",
     "UbiquiStick",
     "Unassigns",

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -33,6 +33,11 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     }
 
     /// @inheritdoc IUbiquityPool
+    function collateralRatio() external view returns (uint256) {
+        return LibUbiquityPool.collateralRatio();
+    }
+
+    /// @inheritdoc IUbiquityPool
     function collateralUsdBalance()
         external
         view
@@ -178,6 +183,11 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
             chainLinkPriceFeedAddress,
             stalenessThreshold
         );
+    }
+
+    /// @inheritdoc IUbiquityPool
+    function setCollateralRatio(uint256 newCollateralRatio) external onlyAdmin {
+        LibUbiquityPool.setCollateralRatio(newCollateralRatio);
     }
 
     /// @inheritdoc IUbiquityPool

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -84,6 +84,15 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     }
 
     /// @inheritdoc IUbiquityPool
+    function getGovernancePriceUsd()
+        external
+        view
+        returns (uint256 governancePriceUsd)
+    {
+        return LibUbiquityPool.getGovernancePriceUsd();
+    }
+
+    /// @inheritdoc IUbiquityPool
     function getRedeemCollateralBalance(
         address userAddress,
         uint256 collateralIndex

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -86,6 +86,11 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
             );
     }
 
+    /// @inheritdoc IUbiquityPool
+    function governanceEthPoolAddress() external view returns (address) {
+        return LibUbiquityPool.governanceEthPoolAddress();
+    }
+
     //====================
     // Public functions
     //====================
@@ -197,6 +202,15 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
         uint256 newRedeemFee
     ) external onlyAdmin {
         LibUbiquityPool.setFees(collateralIndex, newMintFee, newRedeemFee);
+    }
+
+    /// @inheritdoc IUbiquityPool
+    function setGovernanceEthPoolAddress(
+        address newGovernanceEthPoolAddress
+    ) external onlyAdmin {
+        LibUbiquityPool.setGovernanceEthPoolAddress(
+            newGovernanceEthPoolAddress
+        );
     }
 
     /// @inheritdoc IUbiquityPool

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -171,7 +171,11 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     /// @inheritdoc IUbiquityPool
     function collectRedemption(
         uint256 collateralIndex
-    ) external nonReentrant returns (uint256 collateralAmount) {
+    )
+        external
+        nonReentrant
+        returns (uint256 governanceAmount, uint256 collateralAmount)
+    {
         return LibUbiquityPool.collectRedemption(collateralIndex);
     }
 

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -105,6 +105,13 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     }
 
     /// @inheritdoc IUbiquityPool
+    function getRedeemGovernanceBalance(
+        address userAddress
+    ) external view returns (uint256) {
+        return LibUbiquityPool.getRedeemGovernanceBalance(userAddress);
+    }
+
+    /// @inheritdoc IUbiquityPool
     function governanceEthPoolAddress() external view returns (address) {
         return LibUbiquityPool.governanceEthPoolAddress();
     }
@@ -145,12 +152,18 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     function redeemDollar(
         uint256 collateralIndex,
         uint256 dollarAmount,
+        uint256 governanceOutMin,
         uint256 collateralOutMin
-    ) external nonReentrant returns (uint256 collateralOut) {
+    )
+        external
+        nonReentrant
+        returns (uint256 collateralOut, uint256 governanceOut)
+    {
         return
             LibUbiquityPool.redeemDollar(
                 collateralIndex,
                 dollarAmount,
+                governanceOutMin,
                 collateralOutMin
             );
     }

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -118,18 +118,26 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
         uint256 collateralIndex,
         uint256 dollarAmount,
         uint256 dollarOutMin,
-        uint256 maxCollateralIn
+        uint256 maxCollateralIn,
+        uint256 maxGovernanceIn,
+        bool isOneToOne
     )
         external
         nonReentrant
-        returns (uint256 totalDollarMint, uint256 collateralNeeded)
+        returns (
+            uint256 totalDollarMint,
+            uint256 collateralNeeded,
+            uint256 governanceNeeded
+        )
     {
         return
             LibUbiquityPool.mintDollar(
                 collateralIndex,
                 dollarAmount,
                 dollarOutMin,
-                maxCollateralIn
+                maxCollateralIn,
+                maxGovernanceIn,
+                isOneToOne
             );
     }
 

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -47,6 +47,15 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     }
 
     /// @inheritdoc IUbiquityPool
+    function ethUsdPriceFeedInformation()
+        external
+        view
+        returns (address, uint256)
+    {
+        return LibUbiquityPool.ethUsdPriceFeedInformation();
+    }
+
+    /// @inheritdoc IUbiquityPool
     function freeCollateralBalance(
         uint256 collateralIndex
     ) external view returns (uint256) {
@@ -193,6 +202,17 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     /// @inheritdoc IUbiquityPool
     function setCollateralRatio(uint256 newCollateralRatio) external onlyAdmin {
         LibUbiquityPool.setCollateralRatio(newCollateralRatio);
+    }
+
+    /// @inheritdoc IUbiquityPool
+    function setEthUsdChainLinkPriceFeed(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
+    ) external onlyAdmin {
+        LibUbiquityPool.setEthUsdChainLinkPriceFeed(
+            newPriceFeedAddress,
+            newStalenessThreshold
+        );
     }
 
     /// @inheritdoc IUbiquityPool

--- a/packages/contracts/src/dollar/interfaces/ICurveTwocryptoOptimized.sol
+++ b/packages/contracts/src/dollar/interfaces/ICurveTwocryptoOptimized.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {ICurveStableSwapMetaNG} from "./ICurveStableSwapMetaNG.sol";
+
+/**
+ * @notice Curve's CurveTwocryptoOptimized interface
+ *
+ * @dev Differences between Curve's crypto and stable swap meta pools (and how Ubiquity organization uses them):
+ * 1. They contain different tokens:
+ * a) Curve's stable swap metapool containts Dollar/3CRVLP pair
+ * b) Curve's crypto pool contains Governance/ETH pair
+ * 2. They use different bonding curve shapes:
+ * a) Curve's stable swap metapool is more straight (because underlying tokens are pegged to USD)
+ * b) Curve's crypto pool resembles Uniswap's bonding curve (because underlying tokens are not USD pegged)
+ *
+ * @dev Basically `ICurveTwocryptoOptimized` has the same interface as `ICurveStableSwapMetaNG`
+ * but we distinguish them in the code for clarity.
+ */
+interface ICurveTwocryptoOptimized is ICurveStableSwapMetaNG {}

--- a/packages/contracts/src/dollar/interfaces/ICurveTwocryptoOptimized.sol
+++ b/packages/contracts/src/dollar/interfaces/ICurveTwocryptoOptimized.sol
@@ -13,8 +13,18 @@ import {ICurveStableSwapMetaNG} from "./ICurveStableSwapMetaNG.sol";
  * 2. They use different bonding curve shapes:
  * a) Curve's stable swap metapool is more straight (because underlying tokens are pegged to USD)
  * b) Curve's crypto pool resembles Uniswap's bonding curve (because underlying tokens are not USD pegged)
+ * 3. The `price_oracle()` method works differently:
+ * a) Curve's stable swap metapool `price_oracle(uint256 i)` accepts coin index parameter
+ * b) Curve's crypto pool `price_oracle()` doesn't accept coin index parameter and always returns oracle price for coin at index 1
  *
  * @dev Basically `ICurveTwocryptoOptimized` has the same interface as `ICurveStableSwapMetaNG`
  * but we distinguish them in the code for clarity.
  */
-interface ICurveTwocryptoOptimized is ICurveStableSwapMetaNG {}
+interface ICurveTwocryptoOptimized is ICurveStableSwapMetaNG {
+    /**
+     * @notice Getter for the oracle price of the coin at index 1 with regard to the coin at index 0.
+     * The price oracle is an exponential moving average with a periodicity determined by `ma_time`.
+     * @return Price oracle
+     */
+    function price_oracle() external view returns (uint256);
+}

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -83,6 +83,19 @@ interface IUbiquityPool {
     function getDollarPriceUsd() external view returns (uint256 dollarPriceUsd);
 
     /**
+     * @notice Returns Governance token price in USD (6 decimals precision)
+     * @dev How it works:
+     * 1. Fetch ETH/USD price from chainlink oracle
+     * 2. Fetch Governance/ETH price from Curve's oracle
+     * 3. Calculate Governance token price in USD
+     * @return governancePriceUsd Governance token price in USD
+     */
+    function getGovernancePriceUsd()
+        external
+        view
+        returns (uint256 governancePriceUsd);
+
+    /**
      * @notice Returns user's balance available for redemption
      * @param userAddress User address
      * @param collateralIndex Collateral token index

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -33,6 +33,12 @@ interface IUbiquityPool {
         returns (LibUbiquityPool.CollateralInformation memory returnData);
 
     /**
+     * @notice Returns current collateral ratio
+     * @return Collateral ratio
+     */
+    function collateralRatio() external view returns (uint256);
+
+    /**
      * @notice Returns USD value of all collateral tokens held in the pool, in E18
      * @return balanceTally USD value of all collateral tokens
      */
@@ -128,6 +134,12 @@ interface IUbiquityPool {
         uint256 collateralIndex
     ) external returns (uint256 collateralAmount);
 
+    /**
+     * @notice Updates collateral token price in USD from ChainLink price feed
+     * @param collateralIndex Collateral token index
+     */
+    function updateChainLinkCollateralPrice(uint256 collateralIndex) external;
+
     //=========================
     // AMO minters functions
     //=========================
@@ -181,10 +193,20 @@ interface IUbiquityPool {
     ) external;
 
     /**
-     * @notice Updates collateral token price in USD from ChainLink price feed
-     * @param collateralIndex Collateral token index
+     * @notice Sets collateral ratio
+     * @dev How much collateral/governance tokens user should provide/get to mint/redeem Dollar tokens, 1e6 precision
+     *
+     * @dev Example (1_000_000 = 100%):
+     * - Mint: user provides 1 collateral token to get 1 Dollar
+     * - Redeem: user gets 1 collateral token for 1 Dollar
+     *
+     * @dev Example (900_000 = 90%):
+     * - Mint: user provides 0.9 collateral token and 0.1 Governance token to get 1 Dollar
+     * - Redeem: user gets 0.9 collateral token and 0.1 Governance token for 1 Dollar
+     *
+     * @param newCollateralRatio New collateral ratio
      */
-    function updateChainLinkCollateralPrice(uint256 collateralIndex) external;
+    function setCollateralRatio(uint256 newCollateralRatio) external;
 
     /**
      * @notice Sets mint and redeem fees, 1_000_000 = 100%

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -84,6 +84,12 @@ interface IUbiquityPool {
         uint256 collateralIndex
     ) external view returns (uint256);
 
+    /**
+     * @notice Returns pool address for Governance/ETH pair
+     * @return Pool address
+     */
+    function governanceEthPoolAddress() external view returns (address);
+
     //====================
     // Public functions
     //====================
@@ -218,6 +224,21 @@ interface IUbiquityPool {
         uint256 collateralIndex,
         uint256 newMintFee,
         uint256 newRedeemFee
+    ) external;
+
+    /**
+     * @notice Sets a new pool address for Governance/ETH pair
+     *
+     * @dev Based on Curve's CurveTwocryptoOptimized contract. Used for fetching Governance token USD price.
+     * How it works:
+     * 1. Fetch Governance/ETH price from CurveTwocryptoOptimized's built-in oracle
+     * 2. Fetch ETH/USD price from chainlink feed
+     * 3. Calculate Governance token price in USD
+     *
+     * @param newGovernanceEthPoolAddress New pool address for Governance/ETH pair
+     */
+    function setGovernanceEthPoolAddress(
+        address newGovernanceEthPoolAddress
     ) external;
 
     /**

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -178,11 +178,12 @@ interface IUbiquityPool {
      * @dev 2. `collectRedemption()`
      * @dev This is done in order to prevent someone using a flash loan of a collateral token to mint, redeem, and collect in a single transaction/block
      * @param collateralIndex Collateral token index being collected
+     * @return governanceAmount Amount of Governance tokens redeemed
      * @return collateralAmount Amount of collateral tokens redeemed
      */
     function collectRedemption(
         uint256 collateralIndex
-    ) external returns (uint256 collateralAmount);
+    ) external returns (uint256 governanceAmount, uint256 collateralAmount);
 
     /**
      * @notice Updates collateral token price in USD from ChainLink price feed

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -107,6 +107,15 @@ interface IUbiquityPool {
     ) external view returns (uint256);
 
     /**
+     * @notice Returns user's Governance tokens balance available for redemption
+     * @param userAddress User address
+     * @return User's Governance tokens balance available for redemption
+     */
+    function getRedeemGovernanceBalance(
+        address userAddress
+    ) external view returns (uint256);
+
+    /**
      * @notice Returns pool address for Governance/ETH pair
      * @return Pool address
      */
@@ -151,14 +160,16 @@ interface IUbiquityPool {
      * @dev This is done in order to prevent someone using a flash loan of a collateral token to mint, redeem, and collect in a single transaction/block
      * @param collateralIndex Collateral token index being withdrawn
      * @param dollarAmount Amount of Ubiquity Dollars being burned
+     * @param governanceOutMin Minimum amount of Governance tokens that'll be withdrawn, used to set acceptable slippage
      * @param collateralOutMin Minimum amount of collateral tokens that'll be withdrawn, used to set acceptable slippage
      * @return collateralOut Amount of collateral tokens ready for redemption
      */
     function redeemDollar(
         uint256 collateralIndex,
         uint256 dollarAmount,
+        uint256 governanceOutMin,
         uint256 collateralOutMin
-    ) external returns (uint256 collateralOut);
+    ) external returns (uint256 collateralOut, uint256 governanceOut);
 
     /**
      * @notice Used to collect collateral tokens after redeeming/burning Ubiquity Dollars

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -122,15 +122,26 @@ interface IUbiquityPool {
      * @param dollarAmount Amount of dollars to mint
      * @param dollarOutMin Min amount of dollars to mint (slippage protection)
      * @param maxCollateralIn Max amount of collateral to send (slippage protection)
+     * @param maxGovernanceIn Max amount of Governance tokens to send (slippage protection)
+     * @param isOneToOne Force providing only collateral without Governance tokens
      * @return totalDollarMint Amount of Dollars minted
      * @return collateralNeeded Amount of collateral sent to the pool
+     * @return governanceNeeded Amount of Governance tokens burnt from sender
      */
     function mintDollar(
         uint256 collateralIndex,
         uint256 dollarAmount,
         uint256 dollarOutMin,
-        uint256 maxCollateralIn
-    ) external returns (uint256 totalDollarMint, uint256 collateralNeeded);
+        uint256 maxCollateralIn,
+        uint256 maxGovernanceIn,
+        bool isOneToOne
+    )
+        external
+        returns (
+            uint256 totalDollarMint,
+            uint256 collateralNeeded,
+            uint256 governanceNeeded
+        );
 
     /**
      * @notice Burns redeemable Ubiquity Dollars and sends back 1 USD of collateral token for every 1 Ubiquity Dollar burned

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -48,6 +48,15 @@ interface IUbiquityPool {
         returns (uint256 balanceTally);
 
     /**
+     * @notice Returns chainlink price feed information for ETH/USD pair
+     * @return Price feed address and staleness threshold in seconds
+     */
+    function ethUsdPriceFeedInformation()
+        external
+        view
+        returns (address, uint256);
+
+    /**
      * @notice Returns free collateral balance (i.e. that can be borrowed by AMO minters)
      * @param collateralIndex collateral token index
      * @return Amount of free collateral
@@ -213,6 +222,16 @@ interface IUbiquityPool {
      * @param newCollateralRatio New collateral ratio
      */
     function setCollateralRatio(uint256 newCollateralRatio) external;
+
+    /**
+     * @notice Sets chainlink params for ETH/USD price feed
+     * @param newPriceFeedAddress New chainlink price feed address for ETH/USD pair
+     * @param newStalenessThreshold New threshold in seconds when chainlink's ETH/USD price feed answer should be considered stale
+     */
+    function setEthUsdChainLinkPriceFeed(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
+    ) external;
 
     /**
      * @notice Sets mint and redeem fees, 1_000_000 = 100%

--- a/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
+++ b/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
@@ -92,6 +92,10 @@ library LibUbiquityPool {
         //====================================
         // Governance token pricing related
         //====================================
+        // chainlink price feed for ETH/USD pair
+        address ethUsdPriceFeedAddress;
+        // threshold in seconds when chainlink's ETH/USD price feed answer should be considered stale
+        uint256 ethUsdPriceFeedStalenessThreshold;
         // Curve's CurveTwocryptoOptimized contract for Governance/ETH pair
         address governanceEthPoolAddress;
     }
@@ -149,6 +153,11 @@ library LibUbiquityPool {
     event CollateralRatioSet(uint256 newCollateralRatio);
     /// @notice Emitted on enabling/disabling a particular collateral token
     event CollateralToggled(uint256 collateralIndex, bool newState);
+    /// @notice Emitted on setting chainlink's price feed for ETH/USD pair
+    event EthUsdPriceFeedSet(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
+    );
     /// @notice Emitted when fees are updated
     event FeesSet(
         uint256 collateralIndex,
@@ -296,6 +305,22 @@ library LibUbiquityPool {
                 .mul(poolStorage.collateralPrices[i])
                 .div(UBIQUITY_POOL_PRICE_PRECISION);
         }
+    }
+
+    /**
+     * @notice Returns chainlink price feed information for ETH/USD pair
+     * @return Price feed address and staleness threshold in seconds
+     */
+    function ethUsdPriceFeedInformation()
+        internal
+        view
+        returns (address, uint256)
+    {
+        UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
+        return (
+            poolStorage.ethUsdPriceFeedAddress,
+            poolStorage.ethUsdPriceFeedStalenessThreshold
+        );
     }
 
     /**
@@ -827,6 +852,23 @@ library LibUbiquityPool {
         poolStorage.collateralRatio = newCollateralRatio;
 
         emit CollateralRatioSet(newCollateralRatio);
+    }
+
+    /**
+     * @notice Sets chainlink params for ETH/USD price feed
+     * @param newPriceFeedAddress New chainlink price feed address for ETH/USD pair
+     * @param newStalenessThreshold New threshold in seconds when chainlink's ETH/USD price feed answer should be considered stale
+     */
+    function setEthUsdChainLinkPriceFeed(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
+    ) internal {
+        UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
+
+        poolStorage.ethUsdPriceFeedAddress = newPriceFeedAddress;
+        poolStorage.ethUsdPriceFeedStalenessThreshold = newStalenessThreshold;
+
+        emit EthUsdPriceFeedSet(newPriceFeedAddress, newStalenessThreshold);
     }
 
     /**

--- a/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
+++ b/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
@@ -48,6 +48,8 @@ library LibUbiquityPool {
         uint256[] collateralPriceFeedStalenessThresholds;
         // collateral index -> collateral price
         uint256[] collateralPrices;
+        // how much collateral/governance tokens user should provide/get to mint/redeem Dollar tokens, 1e6 precision
+        uint256 collateralRatio;
         // array collateral symbols
         string[] collateralSymbols;
         // collateral address -> is it enabled
@@ -138,6 +140,8 @@ library LibUbiquityPool {
     );
     /// @notice Emitted on setting a collateral price
     event CollateralPriceSet(uint256 collateralIndex, uint256 newPrice);
+    /// @notice Emitted on setting a collateral ratio
+    event CollateralRatioSet(uint256 newCollateralRatio);
     /// @notice Emitted on enabling/disabling a particular collateral token
     event CollateralToggled(uint256 collateralIndex, bool newState);
     /// @notice Emitted when fees are updated
@@ -256,6 +260,15 @@ library LibUbiquityPool {
             poolStorage.mintingFee[index],
             poolStorage.redemptionFee[index]
         );
+    }
+
+    /**
+     * @notice Returns current collateral ratio
+     * @return Collateral ratio
+     */
+    function collateralRatio() internal view returns (uint256) {
+        UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
+        return poolStorage.collateralRatio;
     }
 
     /**
@@ -776,6 +789,28 @@ library LibUbiquityPool {
             chainLinkPriceFeedAddress,
             stalenessThreshold
         );
+    }
+
+    /**
+     * @notice Sets collateral ratio
+     * @dev How much collateral/governance tokens user should provide/get to mint/redeem Dollar tokens, 1e6 precision
+     *
+     * @dev Example (1_000_000 = 100%):
+     * - Mint: user provides 1 collateral token to get 1 Dollar
+     * - Redeem: user gets 1 collateral token for 1 Dollar
+     *
+     * @dev Example (900_000 = 90%):
+     * - Mint: user provides 0.9 collateral token and 0.1 Governance token to get 1 Dollar
+     * - Redeem: user gets 0.9 collateral token and 0.1 Governance token for 1 Dollar
+     *
+     * @param newCollateralRatio New collateral ratio
+     */
+    function setCollateralRatio(uint256 newCollateralRatio) internal {
+        UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
+
+        poolStorage.collateralRatio = newCollateralRatio;
+
+        emit CollateralRatioSet(newCollateralRatio);
     }
 
     /**

--- a/packages/contracts/src/dollar/mocks/MockCurveTwocryptoOptimized.sol
+++ b/packages/contracts/src/dollar/mocks/MockCurveTwocryptoOptimized.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {ICurveTwocryptoOptimized} from "../interfaces/ICurveTwocryptoOptimized.sol";
+import {MockCurveStableSwapMetaNG} from "./MockCurveStableSwapMetaNG.sol";
+
+contract MockCurveTwocryptoOptimized is
+    ICurveTwocryptoOptimized,
+    MockCurveStableSwapMetaNG
+{
+    constructor(
+        address _token0,
+        address _token1
+    ) MockCurveStableSwapMetaNG(_token0, _token1) {}
+}

--- a/packages/contracts/src/dollar/mocks/MockCurveTwocryptoOptimized.sol
+++ b/packages/contracts/src/dollar/mocks/MockCurveTwocryptoOptimized.sol
@@ -12,4 +12,8 @@ contract MockCurveTwocryptoOptimized is
         address _token0,
         address _token1
     ) MockCurveStableSwapMetaNG(_token0, _token1) {}
+
+    function price_oracle() external view returns (uint256) {
+        return priceOracle;
+    }
 }

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -446,9 +446,13 @@ abstract contract DiamondTestSetup is DiamondTestHelper, UUPSTestHelper {
             CREDIT_TOKEN_BURNER_ROLE,
             address(diamond)
         );
-        // grant diamond token admin rights
+        // grant diamond Governance token admin and burner rights
         accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MANAGER_ROLE,
+            address(diamond)
+        );
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_BURNER_ROLE,
             address(diamond)
         );
         // grant diamond token minter rights

--- a/packages/contracts/test/diamond/DiamondTestSetup.sol
+++ b/packages/contracts/test/diamond/DiamondTestSetup.sol
@@ -446,9 +446,13 @@ abstract contract DiamondTestSetup is DiamondTestHelper, UUPSTestHelper {
             CREDIT_TOKEN_BURNER_ROLE,
             address(diamond)
         );
-        // grant diamond Governance token admin and burner rights
+        // grant diamond Governance token admin, minter and burner rights
         accessControlFacet.grantRole(
             GOVERNANCE_TOKEN_MANAGER_ROLE,
+            address(diamond)
+        );
+        accessControlFacet.grantRole(
+            GOVERNANCE_TOKEN_MINTER_ROLE,
             address(diamond)
         );
         accessControlFacet.grantRole(

--- a/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/UbiquityPoolFacet.t.sol
@@ -37,6 +37,7 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         uint256 stalenessThreshold
     );
     event CollateralPriceSet(uint256 collateralIndex, uint256 newPrice);
+    event CollateralRatioSet(uint256 newCollateralRatio);
     event CollateralToggled(uint256 collateralIndex, bool newState);
     event FeesSet(
         uint256 collateralIndex,
@@ -94,6 +95,9 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
             address(collateralTokenPriceFeed), // price feed address
             1 days // price feed staleness threshold in seconds
         );
+
+        // set collateral ratio to 100%
+        ubiquityPoolFacet.setCollateralRatio(1_000_000);
 
         // enable collateral at index 0
         ubiquityPoolFacet.toggleCollateral(0);
@@ -195,6 +199,11 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
         assertEq(info.isBorrowPaused, false);
         assertEq(info.mintingFee, 10000);
         assertEq(info.redemptionFee, 20000);
+    }
+
+    function testCollateralRatio_ShouldReturnCollateralRatio() public {
+        uint256 collateralRatio = ubiquityPoolFacet.collateralRatio();
+        assertEq(collateralRatio, 1_000_000);
     }
 
     function testCollateralUsdBalance_ShouldReturnTotalAmountOfCollateralInUsd()
@@ -879,6 +888,22 @@ contract UbiquityPoolFacetTest is DiamondTestSetup {
             info.collateralPriceFeedStalenessThreshold,
             newStalenessThreshold
         );
+
+        vm.stopPrank();
+    }
+
+    function testSetCollateralRatio_ShouldSetCollateralRatio() public {
+        vm.startPrank(admin);
+
+        uint256 oldCollateralRatio = ubiquityPoolFacet.collateralRatio();
+        assertEq(oldCollateralRatio, 1_000_000);
+
+        uint256 newCollateralRatio = 900_000;
+        vm.expectEmit(address(ubiquityPoolFacet));
+        emit CollateralRatioSet(newCollateralRatio);
+        ubiquityPoolFacet.setCollateralRatio(newCollateralRatio);
+
+        assertEq(ubiquityPoolFacet.collateralRatio(), newCollateralRatio);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
This PR introduces fractional mint/redeem of the Dollar token based on the collateral ratio which represents how many tokens user has to provide in collateral and governance tokens.

How it worked before:
- mint: user provides 1 LUSD and gets 1 Dollar token
- redeem: user provides 1 Dollar token and gets 1 LUSD

**How it works in this PR**

Example 1 (collateral ratio is 100%):
- mint: user provides 1 LUSD and gets 1 Dollar token
- redeem: user provides 1 Dollar token and gets 1 LUSD

You may see that the behaviour is the same as in the previous code version when collateral ratio is 100%.

Example 2 (collateral ratio is 90%):
- mint: user provides 0.9 LUSD + 0.1 USD in UBQ tokens and gets 1 Dollar token
- redeem: user provides 1 Dollar token and gets 0.9 LUSD + 0.1 USD in UBQ tokens

The main reason why we need the fractional feature from the start is to incentivise initial investors (who staked collateral to get UBQ tokens) to put liquidity in the protocol. The plan is to set collateral ratio to 95% from the start so that initial investors could mint Dollar tokens with a 5% discount which is both profitable for investors and useful for protocol (i.e. Dollar token) liquidity.

The code works the same way as in one of the [popular stablecoins](https://github.com/FraxFinance/frax-solidity/blob/967002fc7f2c5ee9e175cabc763a776a8ed03e01/src/hardhat/contracts/Frax/Pools/FraxPoolV3.sol#L373-L387).

Notice:
1. We let the admin to set the collateral ratio value while the popular stablecoin protocol uses [dynamic collateral ratio](https://github.com/FraxFinance/frax-solidity/blob/967002fc7f2c5ee9e175cabc763a776a8ed03e01/src/hardhat/contracts/Frax/Frax.sol#L197-L221). Dynamic collateral ratio works this way: if stablecoin USD price is >$1.00 for some time then global collateral ratio is dicreased, on the contrary if stablecoin USD price is <$1.00 for some time then global collateral ratio is increased. We omit this mechanic for simplicity.
2. There is also the mechanic of [decollateralization](https://github.com/FraxFinance/frax-solidity/blob/967002fc7f2c5ee9e175cabc763a776a8ed03e01/src/hardhat/contracts/Frax/Pools/FraxPoolV3.sol#L499) and [recollateralization](https://github.com/FraxFinance/frax-solidity/blob/967002fc7f2c5ee9e175cabc763a776a8ed03e01/src/hardhat/contracts/Frax/Pools/FraxPoolV3.sol#L534) which works this way:
a) If collateral ratio is increased from 90% to 100% (dynamically or admin set it) then the pool contains 10% of missing collateral so users can deposit collateral to the pool in exchange for Governance tokens (with some premium) until the actual collateral value hits 100%. It is called recollateralization.
b) On the contrary, in case of decollateralization, if collateral ratio is decreased from 100% to 90% then the pool contains 10% of excess collateral. Users can burn their Governance tokens in exchange for collateral until the actual collateral value is 90%.
Initially we plan to set collateral ratio to 95% and leave it at that level. Besides users can [override](https://github.com/FraxFinance/frax-solidity/blob/967002fc7f2c5ee9e175cabc763a776a8ed03e01/src/hardhat/contracts/Frax/Pools/FraxPoolV3.sol#L360) fractional mechanic on mint. But should we want to update collateral ratio from 95% to some other value after the deployment we'll have to add decollateralization and recollateralization methods to the protocol so that users could rebalance the pool.

P.S. Sadly this PR modifies already audited contracts so we'll have to find somebody from the Sherlock's audit to check the updates
P.P.S Diamond storage check workflow is [failing](https://github.com/ubiquity/ubiquity-dollar/actions/runs/8557216549/job/23448939640?pr=922) which is expected and is ok since the contracts are not deployed yet.
P.P.P.S. I will update mainnet and development deploy script in another PR