### PR TITLE
feat: add ICurveStableSwapNG

### DIFF
--- a/packages/contracts/src/dollar/facets/ManagerFacet.sol
+++ b/packages/contracts/src/dollar/facets/ManagerFacet.sol
@@ -145,6 +145,17 @@ contract ManagerFacet is Modifiers {
     }
 
     /**
+     * @notice Sets Curve's Dollar-Stablecoin plain pool address
+     * @dev `_stableSwapPlainPoolAddress` is used to fetch Dollar price in USD
+     * @param _stableSwapPlainPoolAddress Curve's Dollar-Stablecoin plain pool address
+     */
+    function setStableSwapPlainPoolAddress(
+        address _stableSwapPlainPoolAddress
+    ) external onlyAdmin {
+        store.stableSwapPlainPoolAddress = _stableSwapPlainPoolAddress;
+    }
+
+    /**
      * @notice Sets staking contract address
      * @dev Staking contract participants deposit Curve LP tokens
      * for a certain duration to earn Governance tokens and more Curve LP tokens
@@ -383,6 +394,14 @@ contract ManagerFacet is Modifiers {
      */
     function stableSwapMetaPoolAddress() external view returns (address) {
         return store.stableSwapMetaPoolAddress;
+    }
+
+    /**
+     * @notice Returns Curve's plain pool address for Dollar-Stablecoin pair
+     * @return Curve's plain pool address for Dollar-Stablecoin pair
+     */
+    function stableSwapPlainPoolAddress() external view returns (address) {
+        return store.stableSwapPlainPoolAddress;
     }
 
     /**

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -116,6 +116,15 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
         return LibUbiquityPool.governanceEthPoolAddress();
     }
 
+    /// @inheritdoc IUbiquityPool
+    function stableEthPriceFeedInformation()
+        external
+        view
+        returns (address, uint256)
+    {
+        return LibUbiquityPool.stableEthPriceFeedInformation();
+    }
+
     //====================
     // Public functions
     //====================
@@ -291,6 +300,17 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
         uint256 newRedemptionDelayBlocks
     ) external onlyAdmin {
         LibUbiquityPool.setRedemptionDelayBlocks(newRedemptionDelayBlocks);
+    }
+
+    /// @inheritdoc IUbiquityPool
+    function setStableEthChainLinkPriceFeed(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
+    ) external onlyAdmin {
+        LibUbiquityPool.setStableEthChainLinkPriceFeed(
+            newPriceFeedAddress,
+            newStalenessThreshold
+        );
     }
 
     /// @inheritdoc IUbiquityPool

--- a/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/UbiquityPoolFacet.sol
@@ -117,12 +117,12 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     }
 
     /// @inheritdoc IUbiquityPool
-    function stableEthPriceFeedInformation()
+    function stableUsdPriceFeedInformation()
         external
         view
         returns (address, uint256)
     {
-        return LibUbiquityPool.stableEthPriceFeedInformation();
+        return LibUbiquityPool.stableUsdPriceFeedInformation();
     }
 
     //====================
@@ -303,11 +303,11 @@ contract UbiquityPoolFacet is IUbiquityPool, Modifiers {
     }
 
     /// @inheritdoc IUbiquityPool
-    function setStableEthChainLinkPriceFeed(
+    function setStableUsdChainLinkPriceFeed(
         address newPriceFeedAddress,
         uint256 newStalenessThreshold
     ) external onlyAdmin {
-        LibUbiquityPool.setStableEthChainLinkPriceFeed(
+        LibUbiquityPool.setStableUsdChainLinkPriceFeed(
             newPriceFeedAddress,
             newStalenessThreshold
         );

--- a/packages/contracts/src/dollar/interfaces/ICurveStableSwapNG.sol
+++ b/packages/contracts/src/dollar/interfaces/ICurveStableSwapNG.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {ICurveStableSwapMetaNG} from "./ICurveStableSwapMetaNG.sol";
+
+/**
+ * @notice Curve's interface for plain pool which contains only USD pegged assets
+ */
+interface ICurveStableSwapNG is ICurveStableSwapMetaNG {}

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -121,6 +121,16 @@ interface IUbiquityPool {
      */
     function governanceEthPoolAddress() external view returns (address);
 
+    /**
+     * @notice Returns chainlink price feed information for stable/ETH pair
+     * @dev Here stable coin refers to the 1st coin in the Curve's stable/Dollar plain pool
+     * @return Price feed address and staleness threshold in seconds
+     */
+    function stableEthPriceFeedInformation()
+        external
+        view
+        returns (address, uint256);
+
     //====================
     // Public functions
     //====================
@@ -326,6 +336,16 @@ interface IUbiquityPool {
      */
     function setRedemptionDelayBlocks(
         uint256 newRedemptionDelayBlocks
+    ) external;
+
+    /**
+     * @notice Sets chainlink params for stable/ETH price feed
+     * @param newPriceFeedAddress New chainlink price feed address for stable/ETH pair
+     * @param newStalenessThreshold New threshold in seconds when chainlink's stable/ETH price feed answer should be considered stale
+     */
+    function setStableEthChainLinkPriceFeed(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
     ) external;
 
     /**

--- a/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/IUbiquityPool.sol
@@ -122,11 +122,11 @@ interface IUbiquityPool {
     function governanceEthPoolAddress() external view returns (address);
 
     /**
-     * @notice Returns chainlink price feed information for stable/ETH pair
+     * @notice Returns chainlink price feed information for stable/USD pair
      * @dev Here stable coin refers to the 1st coin in the Curve's stable/Dollar plain pool
      * @return Price feed address and staleness threshold in seconds
      */
-    function stableEthPriceFeedInformation()
+    function stableUsdPriceFeedInformation()
         external
         view
         returns (address, uint256);
@@ -339,11 +339,12 @@ interface IUbiquityPool {
     ) external;
 
     /**
-     * @notice Sets chainlink params for stable/ETH price feed
-     * @param newPriceFeedAddress New chainlink price feed address for stable/ETH pair
-     * @param newStalenessThreshold New threshold in seconds when chainlink's stable/ETH price feed answer should be considered stale
+     * @notice Sets chainlink params for stable/USD price feed
+     * @dev Here stable coin refers to the 1st coin in the Curve's stable/Dollar plain pool
+     * @param newPriceFeedAddress New chainlink price feed address for stable/USD pair
+     * @param newStalenessThreshold New threshold in seconds when chainlink's stable/USD price feed answer should be considered stale
      */
-    function setStableEthChainLinkPriceFeed(
+    function setStableUsdChainLinkPriceFeed(
         address newPriceFeedAddress,
         uint256 newStalenessThreshold
     ) external;

--- a/packages/contracts/src/dollar/libraries/LibAppStorage.sol
+++ b/packages/contracts/src/dollar/libraries/LibAppStorage.sol
@@ -17,6 +17,7 @@ struct AppStorage {
     address stakingShareAddress;
     address stakingContractAddress;
     address stableSwapMetaPoolAddress;
+    address stableSwapPlainPoolAddress;
     address curve3PoolTokenAddress; // 3CRV
     address treasuryAddress;
     address governanceTokenAddress;

--- a/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
+++ b/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
@@ -6,7 +6,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
-import {ICurveStableSwapMetaNG} from "../interfaces/ICurveStableSwapMetaNG.sol";
+import {ICurveStableSwapNG} from "../interfaces/ICurveStableSwapNG.sol";
 import {ICurveTwocryptoOptimized} from "../interfaces/ICurveTwocryptoOptimized.sol";
 import {IDollarAmoMinter} from "../interfaces/IDollarAmoMinter.sol";
 import {IERC20Ubiquity} from "../interfaces/IERC20Ubiquity.sol";
@@ -373,7 +373,7 @@ library LibUbiquityPool {
         // load storage shared across all libraries
         AppStorage storage store = LibAppStorage.appStorage();
         // get Dollar price from Curve Metapool (18 decimals)
-        uint256 dollarPriceUsdD18 = ICurveStableSwapMetaNG(
+        uint256 dollarPriceUsdD18 = ICurveStableSwapNG(
             store.stableSwapMetaPoolAddress
         ).price_oracle(0);
         // convert to 6 decimals

--- a/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
+++ b/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol
@@ -103,6 +103,13 @@ library LibUbiquityPool {
         uint256 ethUsdPriceFeedStalenessThreshold;
         // Curve's CurveTwocryptoOptimized contract for Governance/ETH pair
         address governanceEthPoolAddress;
+        //================================
+        // Dollar token pricing related
+        //================================
+        // chainlink price feed for stable/ETH pair
+        address stableEthPriceFeedAddress;
+        // threshold in seconds when chainlink's stable/ETH price feed answer should be considered stale
+        uint256 stableEthPriceFeedStalenessThreshold;
     }
 
     /// @notice Struct used for detailed collateral information
@@ -182,6 +189,11 @@ library LibUbiquityPool {
     );
     /// @notice Emitted when a new redemption delay in blocks is set
     event RedemptionDelayBlocksSet(uint256 redemptionDelayBlocks);
+    /// @notice Emitted on setting chainlink's price feed for stable/ETH pair
+    event StableEthPriceFeedSet(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
+    );
 
     //=====================
     // Modifiers
@@ -465,6 +477,23 @@ library LibUbiquityPool {
     function governanceEthPoolAddress() internal view returns (address) {
         UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
         return poolStorage.governanceEthPoolAddress;
+    }
+
+    /**
+     * @notice Returns chainlink price feed information for stable/ETH pair
+     * @dev Here stable coin refers to the 1st coin in the Curve's stable/Dollar plain pool
+     * @return Price feed address and staleness threshold in seconds
+     */
+    function stableEthPriceFeedInformation()
+        internal
+        view
+        returns (address, uint256)
+    {
+        UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
+        return (
+            poolStorage.stableEthPriceFeedAddress,
+            poolStorage.stableEthPriceFeedStalenessThreshold
+        );
     }
 
     //====================
@@ -1122,6 +1151,24 @@ library LibUbiquityPool {
         poolStorage.redemptionDelayBlocks = newRedemptionDelayBlocks;
 
         emit RedemptionDelayBlocksSet(newRedemptionDelayBlocks);
+    }
+
+    /**
+     * @notice Sets chainlink params for stable/ETH price feed
+     * @param newPriceFeedAddress New chainlink price feed address for stable/ETH pair
+     * @param newStalenessThreshold New threshold in seconds when chainlink's stable/ETH price feed answer should be considered stale
+     */
+    function setStableEthChainLinkPriceFeed(
+        address newPriceFeedAddress,
+        uint256 newStalenessThreshold
+    ) internal {
+        UbiquityPoolStorage storage poolStorage = ubiquityPoolStorage();
+
+        poolStorage.stableEthPriceFeedAddress = newPriceFeedAddress;
+        poolStorage
+            .stableEthPriceFeedStalenessThreshold = newStalenessThreshold;
+
+        emit StableEthPriceFeedSet(newPriceFeedAddress, newStalenessThreshold);
     }
 
     /**

--- a/packages/contracts/src/dollar/mocks/MockCurveStableSwapNG.sol
+++ b/packages/contracts/src/dollar/mocks/MockCurveStableSwapNG.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {ICurveStableSwapNG} from "../interfaces/ICurveStableSwapNG.sol";
+import {MockCurveStableSwapMetaNG} from "./MockCurveStableSwapMetaNG.sol";
+
+contract MockCurveStableSwapNG is
+    ICurveStableSwapNG,
+    MockCurveStableSwapMetaNG
+{
+    constructor(
+        address _token0,
+        address _token1
+    ) MockCurveStableSwapMetaNG(_token0, _token1) {}
+}

--- a/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/ManagerFacet.t.sol
@@ -85,6 +85,14 @@ contract ManagerFacetTest is DiamondTestSetup {
         assertEq(managerFacet.stableSwapMetaPoolAddress(), contract1);
     }
 
+    function testSetStableSwapPlainPoolAddress_ShouldSucceed()
+        public
+        prankAs(admin)
+    {
+        managerFacet.setStableSwapPlainPoolAddress(contract1);
+        assertEq(managerFacet.stableSwapPlainPoolAddress(), contract1);
+    }
+
     function testSetStakingContractAddress_ShouldSucceed()
         public
         prankAs(admin)


### PR DESCRIPTION
Resolves https://github.com/ubiquity/ubiquity-dollar/issues/931

This PR refactors [LibUbiquityPool](https://github.com/ubiquity/ubiquity-dollar/blob/81f760bdbcf8c9b467ba55014f78ae86c5ca68de/packages/contracts/src/dollar/libraries/LibUbiquityPool.sol) to use [ICurveStableSwapNG](https://docs.curve.fi/stableswap-exchange/stableswap-ng/pools/plainpool/) instead of [ICurveStableSwapMetaNG](https://docs.curve.fi/stableswap-exchange/stableswap-ng/pools/metapool/).

`ICurveStableSwapMetaNG` is basically a `Dollar/3CRV` pool. Keeping in mind that `3CRV` is equal to `$1.03` we can't reliably fetch Dollar price in USD from `ICurveStableSwapMetaNG`.

We plan to create a new `ICurveStableSwapNG` pool with `LUSD/Dollar` pair. So calculating Dollar price in USD works this way:
1) Fetch `LUSD/USD` price from chainlink
2) Fetch `Dollar/LUSD` price from Curve's `ICurveStableSwapNG` [oracle](https://docs.curve.fi/stableswap-exchange/stableswap-ng/pools/oracles/)
3) Now we have everything to calculate `Dollar/USD` price

P.S. Deployment scripts will be updated in a separate PR