### PR TITLE
feat: add plain pool migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ COLLATERAL_TOKEN_ADDRESS="0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
 
 # Collateral token price feed address from chainlink.
 # By default set to LUSD/USD price feed deployed on ethereum mainnet.
+# This price feed is used in 2 cases:
+# 1) To calculate collateral price in USD
+# 2) To calculate Dollar price in USD
+# Since collateral token (LUSD) is the same one used in Curve's plain pool (LUSD-Dollar)
+# we share the same price feed in:
+# 1) `LibUbiquityPool.setCollateralChainLinkPriceFeed()` (to calculate collateral price in USD)
+# 2) `LibUbiquityPool.setStableUsdChainLinkPriceFeed()` (to calculate Dollar price in USD)
 # - mainnet: uses already deployed LUSD/USD chainlink price feed
 # - testnet/anvil: deploys LUSD/USD chainlink price feed from scratch
 COLLATERAL_TOKEN_CHAINLINK_PRICE_FEED_ADDRESS="0x3D7aE7E594f2f2091Ad8798313450130d0Aba3a0"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ CURVE_GOVERNANCE_WETH_POOL_ADDRESS="0xaCDc85AFCD8B83Eb171AFFCbe29FaD204F6ae45C"
 # - testnet/anvil: deploys ETH/USD chainlink price feed from scratch
 ETH_USD_CHAINLINK_PRICE_FEED_ADDRESS="0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419"
 
-# Dollar amount in wei minted initially to provide liquidity to the Dollar-3CRV metapool
+# Dollar amount in wei minted initially to owner to provide liquidity to the Curve LUSD-Dollar plain pool
 # By default set to 25k Dollar tokens
 INITIAL_DOLLAR_MINT_AMOUNT_WEI="25000000000000000000000"
 

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -36,7 +36,7 @@ CURVE_GOVERNANCE_WETH_POOL_ADDRESS="0xaCDc85AFCD8B83Eb171AFFCbe29FaD204F6ae45C"
 # - testnet/anvil: deploys ETH/USD chainlink price feed from scratch
 ETH_USD_CHAINLINK_PRICE_FEED_ADDRESS="0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419"
 
-# Dollar amount in wei minted initially to provide liquidity to the Dollar-3CRV metapool
+# Dollar amount in wei minted initially to owner to provide liquidity to the Curve LUSD-Dollar plain pool
 # By default set to 25k Dollar tokens
 INITIAL_DOLLAR_MINT_AMOUNT_WEI="25000000000000000000000"
 

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -11,6 +11,13 @@ COLLATERAL_TOKEN_ADDRESS="0x5f98805A4E8be255a32880FDeC7F6728C6568bA0"
 
 # Collateral token price feed address from chainlink.
 # By default set to LUSD/USD price feed deployed on ethereum mainnet.
+# This price feed is used in 2 cases:
+# 1) To calculate collateral price in USD
+# 2) To calculate Dollar price in USD
+# Since collateral token (LUSD) is the same one used in Curve's plain pool (LUSD-Dollar)
+# we share the same price feed in:
+# 1) `LibUbiquityPool.setCollateralChainLinkPriceFeed()` (to calculate collateral price in USD)
+# 2) `LibUbiquityPool.setStableUsdChainLinkPriceFeed()` (to calculate Dollar price in USD)
 # - mainnet: uses already deployed LUSD/USD chainlink price feed
 # - testnet/anvil: deploys LUSD/USD chainlink price feed from scratch
 COLLATERAL_TOKEN_CHAINLINK_PRICE_FEED_ADDRESS="0x3D7aE7E594f2f2091Ad8798313450130d0Aba3a0"

--- a/packages/contracts/src/dollar/interfaces/ICurveStableSwapFactoryNG.sol
+++ b/packages/contracts/src/dollar/interfaces/ICurveStableSwapFactoryNG.sol
@@ -19,7 +19,7 @@ interface ICurveStableSwapFactoryNG {
      * @param _A Amplification coefficient. If set to 0 then bonding curve acts like Uniswap. Any >0 value
      * makes the bonding curve to swap at 1:1 constant price, the more `_A` the longer the constant price period.
      * Curve recommends set it to 100 for crypto collateralizard stablecoins. This parameter can be updated later.
-     * @param _fee Trade fee, given as an integer with 1e10 precision, ex: 40000000 = 0.04% fee
+     * @param _fee Trade fee, given as an integer with 1e10 precision, ex: 4000000 = 0.04% fee
      * @param _offpeg_fee_multiplier Off-peg multiplier. Curve recommends set it to `20000000000`. This parameter can be updated
      * later. More info: https://docs.curve.fi/stableswap-exchange/stableswap-ng/pools/overview/#dynamic-fees
      * @param _ma_exp_time MA time; set as time_in_seconds / ln(2), ex: 866 = 600 seconds, 2597 = 1800 seconds.
@@ -53,5 +53,48 @@ interface ICurveStableSwapFactoryNG {
         uint8 _asset_type,
         bytes4 _method_id,
         address _oracle
+    ) external returns (address);
+
+    /**
+     * @notice Deploys a new plain pool
+     * @param _name Name of the new plain pool, ex: "LUSD/Dollar"
+     * @param _symbol Symbol for the new pool's LP token, ex: "LUSDDollar"
+     * @param _coins Array of addresses of the coins being used in the pool
+     * @param _A Amplification coefficient. If set to 0 then bonding curve acts like Uniswap. Any >0 value
+     * makes the bonding curve to swap at 1:1 constant price, the more `_A` the longer the constant price period.
+     * Curve recommends set it to 100 for crypto collateralizard stablecoins. This parameter can be updated later.
+     * @param _fee Trade fee, given as an integer with 1e10 precision, ex: 4000000 = 0.04% fee
+     * @param _offpeg_fee_multiplier Off-peg multiplier. Curve recommends set it to `20000000000`. This parameter can be updated
+     * later. More info: https://docs.curve.fi/stableswap-exchange/stableswap-ng/pools/overview/#dynamic-fees
+     * @param _ma_exp_time MA time; set as time_in_seconds / ln(2), ex: 866 = 600 seconds, 2597 = 1800 seconds.
+     * This parameter can be updated later.
+     * @param _implementation_idx Index of the plain pool implementation to use. Can be retrieved
+     * via `ICurveStableSwapFactoryNG.pool_implementations()`. There is only 1 plain pool implementation right now
+     * so use index `0`.
+     * @param _asset_types Asset types of the pool tokens as an integer. Available asset type indexes:
+     * - 0: Standard ERC20 token with no additional features
+     * - 1: Oracle - token with rate oracle (e.g. wstETH)
+     * - 2: Rebasing - token with rebase (e.g. stETH)
+     * - 3: ERC4626 - token with convertToAssets method (e.g. sDAI)
+     * Both Dollar and LUSD are standard ERC20 tokens so we should use asset types with index `0`.
+     * @param _method_ids Array of first four bytes of the Keccak-256 hash of the function signatures of
+     * the oracle addresses that give rate oracles. This is applied only to asset type `1` (Oracle).
+     * For Dollar token deployment set empty.
+     * @param _oracles Array of rate oracle addresses. This is applied only to asset type `1` (Oracle).
+     * For Dollar token deployment set empty address.
+     * @return Deployed plain pool address
+     */
+    function deploy_plain_pool(
+        string memory _name,
+        string memory _symbol,
+        address[] memory _coins,
+        uint256 _A,
+        uint256 _fee,
+        uint256 _offpeg_fee_multiplier,
+        uint256 _ma_exp_time,
+        uint256 _implementation_idx,
+        uint8[] memory _asset_types,
+        bytes4[] memory _method_ids,
+        address[] memory _oracles
     ) external returns (address);
 }

--- a/packages/contracts/src/dollar/interfaces/ICurveStableSwapNG.sol
+++ b/packages/contracts/src/dollar/interfaces/ICurveStableSwapNG.sol
@@ -6,4 +6,10 @@ import {ICurveStableSwapMetaNG} from "./ICurveStableSwapMetaNG.sol";
 /**
  * @notice Curve's interface for plain pool which contains only USD pegged assets
  */
-interface ICurveStableSwapNG is ICurveStableSwapMetaNG {}
+interface ICurveStableSwapNG is ICurveStableSwapMetaNG {
+    function add_liquidity(
+        uint256[] memory _amounts,
+        uint256 _min_mint_amount,
+        address _receiver
+    ) external returns (uint256);
+}

--- a/packages/contracts/src/dollar/mocks/MockCurveStableSwapMetaNG.sol
+++ b/packages/contracts/src/dollar/mocks/MockCurveStableSwapMetaNG.sol
@@ -19,7 +19,7 @@ contract MockCurveStableSwapMetaNG is ICurveStableSwapMetaNG, MockERC20 {
         uint256[2] memory _amounts,
         uint256 _min_mint_amount,
         address _receiver
-    ) external returns (uint256 result) {
+    ) public returns (uint256 result) {
         mint(
             _receiver,
             _min_mint_amount == 0

--- a/packages/contracts/src/dollar/mocks/MockCurveStableSwapNG.sol
+++ b/packages/contracts/src/dollar/mocks/MockCurveStableSwapNG.sol
@@ -12,4 +12,13 @@ contract MockCurveStableSwapNG is
         address _token0,
         address _token1
     ) MockCurveStableSwapMetaNG(_token0, _token1) {}
+
+    function add_liquidity(
+        uint256[] memory _amounts,
+        uint256 _min_mint_amount,
+        address _receiver
+    ) external returns (uint256 result) {
+        uint256[2] memory amounts = [_amounts[0], _amounts[1]];
+        return add_liquidity(amounts, _min_mint_amount, _receiver);
+    }
 }


### PR DESCRIPTION
This PR updates deployment migrations to use `ICurveStableSwapNG` instead of `ICurveStableSwapMetaNG`

P.S. Mainnet deployment was tested with [this](https://gist.github.com/rndquu/6797b0d7b9110e0b8faae6304ca600d9) test file