### PR TITLE
chore: skip check_storage_layout check if provide_contracts job retur…

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -46,6 +46,7 @@ jobs:
   check_storage_layout:
     needs: provide_contracts
     runs-on: ubuntu-latest
+    if: ${{ needs.provide_contracts.outputs.matrix != '[]' && needs.provide_contracts.outputs.matrix != '' }}
 
     strategy:
       matrix:

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -50,6 +50,7 @@ jobs:
   check_storage_layout:
     needs: provide_contracts
     runs-on: ubuntu-latest
+    if: ${{ needs.provide_contracts.outputs.matrix != '[]' && needs.provide_contracts.outputs.matrix != '' }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Prevent fromJSON failure in check storage layout workflows by checking provide_contracts output before triggering matrix strategy.

Resolves: https://github.com/ubiquity/ubiquity-dollar/issues/942

QA on my fork:  https://github.com/gitcoindev/ubiquity-dollar/actions/runs/9686630787/job/26729492711?pr=22

Based on 'How to handle empty matrix' solution for https://github.com/dorny/paths-filter/issues/66
