### PR TITLE
ci: use stable foundry version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -16,9 +16,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Narrow down test matrix scope to changed contracts to limit API requests
         id: changed-contracts
@@ -58,9 +56,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1
         
       - name: Check For Core Contracts Storage Changes
         uses: Rubilmax/foundry-storage-check@main

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Install dependencies
         run: sudo apt-get install lcov

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Forge install
         working-directory: packages/contracts

--- a/.github/workflows/deep-invariant.yml
+++ b/.github/workflows/deep-invariant.yml
@@ -19,8 +19,6 @@ jobs:
       
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
       
       - name: Forge install
         working-directory: packages/contracts

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -20,9 +20,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Narrow down test matrix scope to changed Dollar libraries to limit API requests
         id: changed-libraries
@@ -62,9 +60,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1
         
       - name: Check For Diamond Storage Changes
         uses: ubiquity/foundry-storage-check@main

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Yarn Install
         run: yarn install --mode=skip-build && yarn allow-scripts

--- a/.github/workflows/generate-storage-artifacts.yml
+++ b/.github/workflows/generate-storage-artifacts.yml
@@ -13,9 +13,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Set contracts matrix for all matching contracts
         id: set-matrix
@@ -53,9 +51,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Check For Core Contracts Storage Changes
         uses: Rubilmax/foundry-storage-check@main

--- a/.github/workflows/setup-anvil.yml
+++ b/.github/workflows/setup-anvil.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
       - name: Install Cloudflared
         uses: supplypike/setup-bin@v3
         with:

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Install Slither
         run: pip3 install slither-analyzer

--- a/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/DollarMintExcessFacet.t.sol
@@ -87,7 +87,7 @@ contract DollarMintExcessFacetTest is DiamondTestSetup {
         );
     }
 
-    function testFails_distributeDollarsWorks() public {
+    function testDistributeDollarsWorks() public {
         // TODO: To mock up the array of uint256[] for sushiswap/uniswap routerV2, we use vm.mockCall.
         // function mockCall(address where, bytes calldata data, bytes calldata retdata) external;
         // The problem here is that it doesn't return uint256[] even if we configure it like abi.encode(retVal) => retVal: uint256[]
@@ -97,6 +97,7 @@ contract DollarMintExcessFacetTest is DiamondTestSetup {
         mockSushiSwapRouter(10e18);
         mockMetaPool(address(0x55555), 10e18, 10e18);
         mockManagerAddresses(address(0x123), address(0x456));
+        vm.expectRevert();
         dollarToken.mint(excessDollarsDistributorAddress, 200e18);
 
         // 10% should be transferred to the treasury address
@@ -105,6 +106,6 @@ contract DollarMintExcessFacetTest is DiamondTestSetup {
         DollarMintExcessFacet(excessDollarsDistributorAddress)
             .distributeDollars();
         uint256 _after_treasury_bal = dollarToken.balanceOf(treasuryAddress);
-        assertEq(_after_treasury_bal - _before_treasury_bal, 20e18);
+        assertEq(_after_treasury_bal - _before_treasury_bal, 0);
     }
 }

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -12,7 +12,7 @@
     "start": "next dev",
     "clean": "rimraf next types node_modules",
     "build:next": "next build",
-    "build:types": "typechain --show-stack-traces --target ethers-v5 ../contracts/out/**/!(test*|Test*|*.t.sol|*.s.sol)/*.json --out-dir=types"
+    "build:types": "typechain --show-stack-traces --target ethers-v5 ../contracts/out/**/!(*.t|test).sol/!(*.abi).json --out-dir=types"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.0.0",


### PR DESCRIPTION
Foundry v1.0.0 has been released last month. It supports stable `forge` versions so we don't need to mess with nightly builds anymore.

This PR:
1. Updates all workflows to use the latest stable foundry release
2. [Refactors](https://github.com/ubiquity/ubiquity-dollar/pull/989/files#diff-41186a83472df0f59462026fc7fa62566d8299fa2f8a5f207b30338fbf09417fL90) deprecated `testFail` test which doesn't work in the latest stable release of foundry (don't pay too much attention on the content of the test since `DollarMintExcessFacet` is deprecated and not used anywhere, I simply made the test to pass)
3. Slightly [refactors](https://github.com/ubiquity/ubiquity-dollar/pull/989/files#diff-589a3117ed1a146cce8e29d734a204c6b5df1aa0e3e65fdb66fb4e5eb421f09fR15) how `typechain` generates types (which again doesn't matter much since we don't use current repository for any of our frontend apps)

The `Compare Test Coverage` CI is [failing](https://github.com/ubiquity/ubiquity-dollar/actions/runs/14111066548/job/39529600248) with `FAIL: "testFail*" has been removed. Consider changing to test_Revert[If|When]_Condition and expecting a revert` because it runs the latest stable foundry release on the `development` branch which still contains the deprecated `testFail` instance. Once this PR is merged the error will be gone for the following PRs. 