### PR TITLE
Fix staking migration

### DIFF
--- a/packages/contracts/migrations/development/Deploy002_Staking.s.sol
+++ b/packages/contracts/migrations/development/Deploy002_Staking.s.sol
@@ -98,11 +98,10 @@ contract Deploy002_Staking is Script, DiamondTestHelper {
         stakingFacet.setGovernancePerBlock(0.2 ether); // 0.2 reward token minted per block
         stakingFacet.setGovernanceTreasuryDivider(5); // `100 / 5 = 20%` extra reward tokens minted for treasury
         stakingFacet.setStakingRewardToken(address(rewardToken)); // reward token address
-        stakingFacet.setStakingStartBlock(block.number); // activate staking from current block
+        stakingFacet.setStakingStartBlock(block.number + 10); // activate staking 10 blocks later
         stakingFacet.createStakingPool( // add a new staking pool
             100, // allocation points
-            IERC20(stakeToken), // staking token
-            true // whether to update all pools
+            IERC20(stakeToken) // staking token
         );
 
         // stop sending admin transactions

--- a/packages/contracts/migrations/mainnet/Deploy002_Staking.s.sol
+++ b/packages/contracts/migrations/mainnet/Deploy002_Staking.s.sol
@@ -73,11 +73,10 @@ contract Deploy002_Staking is Script, DiamondTestHelper {
         stakingFacet.setGovernancePerBlock(0.2 ether); // 0.2 reward token minted per block
         stakingFacet.setGovernanceTreasuryDivider(5); // `100 / 5 = 20%` extra reward tokens minted for treasury
         stakingFacet.setStakingRewardToken(ubqToken); // reward token address
-        stakingFacet.setStakingStartBlock(block.number); // activate staking from current block
+        stakingFacet.setStakingStartBlock(block.number + 10); // activate staking 10 blocks later
         stakingFacet.createStakingPool( // add a new staking pool
             100, // allocation points
-            IERC20(lusdUusdLpToken), // staking token
-            true // whether to update all pools
+            IERC20(lusdUusdLpToken) // staking token
         );
 
         // Stop sending owner transactions

--- a/packages/contracts/src/dollar/libraries/LibStaking.sol
+++ b/packages/contracts/src/dollar/libraries/LibStaking.sol
@@ -515,8 +515,11 @@ library LibStaking {
      * @param newStartBlock Block number when staking should be active
      */
     function setStakingStartBlock(uint256 newStartBlock) internal {
-        require(newStartBlock >= block.number, "Can't start in the past");
         StakingStorage storage stakingStore = stakingStorage();
+
+        require(newStartBlock >= block.number, "Can't start in the past");
+        require(newStartBlock > stakingStore.startBlock, "Must be greater than the previous start block");
+
         stakingStore.startBlock = newStartBlock;
         emit StakingStartBlockSet(newStartBlock);
     }

--- a/packages/contracts/src/dollar/libraries/LibStaking.sol
+++ b/packages/contracts/src/dollar/libraries/LibStaking.sol
@@ -295,6 +295,9 @@ library LibStaking {
 
         PoolInfo storage pool = stakingStore.poolInfo[poolId];
         UserInfo storage user = stakingStore.userInfo[poolId][msg.sender];
+
+        require(pool.allocationPoints > 0, "Pool disabled");
+
         updateStakingPool(poolId);
         if (user.amount > 0) {
             uint256 pending = user

--- a/packages/contracts/src/dollar/libraries/LibStaking.sol
+++ b/packages/contracts/src/dollar/libraries/LibStaking.sol
@@ -445,6 +445,7 @@ library LibStaking {
             newGovernanceBonusEndBlock >= block.number,
             "Bonus end block can't be in the past"
         );
+        massUpdateStakingPools();
         StakingStorage storage stakingStore = stakingStorage();
         stakingStore.bonusEndBlock = newGovernanceBonusEndBlock;
         emit GovernanceBonusEndBlockSet(newGovernanceBonusEndBlock);
@@ -457,6 +458,7 @@ library LibStaking {
     function setGovernanceBonusMultiplier(
         uint256 newGovernanceBonusMultiplier
     ) internal {
+        massUpdateStakingPools();
         StakingStorage storage stakingStore = stakingStorage();
         stakingStore.governanceBonusMultiplier = newGovernanceBonusMultiplier;
         emit GovernanceBonusMultiplierSet(newGovernanceBonusMultiplier);
@@ -470,6 +472,7 @@ library LibStaking {
      */
     function setGovernancePerBlock(uint256 newGovernancePerBlock) internal {
         require(newGovernancePerBlock >= 0.0001 ether, "Rewards are too small");
+        massUpdateStakingPools();
         StakingStorage storage stakingStore = stakingStorage();
         stakingStore.governancePerBlock = newGovernancePerBlock;
         emit GovernancePerBlockSet(newGovernancePerBlock);
@@ -485,6 +488,7 @@ library LibStaking {
     function setGovernanceTreasuryDivider(
         uint256 newGovernanceTreasuryDivider
     ) internal {
+        massUpdateStakingPools();
         StakingStorage storage stakingStore = stakingStorage();
         stakingStore.governanceTreasuryDivider = newGovernanceTreasuryDivider;
         emit GovernanceTreasuryDividerSet(newGovernanceTreasuryDivider);

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -827,6 +827,14 @@ contract StakingFacetTest is DiamondTestSetup {
         stakingFacet.setStakingStartBlock(0);
     }
 
+    function testSetStakingStartBlock_ShouldRevert_IfStartBlockIsLessOrEqualToCurrentStartBlock()
+        public
+    {
+        vm.prank(admin);
+        vm.expectRevert("Must be greater than the previous start block");
+        stakingFacet.setStakingStartBlock(1);
+    }
+
     function testSetStakingStartBlock_ShouldUpdateStakingStartBlock() public {
         (, , , , , , , uint256 oldStartBlock) = stakingFacet
             .getStakingSettings();

--- a/packages/contracts/test/diamond/facets/StakingFacet.t.sol
+++ b/packages/contracts/test/diamond/facets/StakingFacet.t.sol
@@ -254,6 +254,20 @@ contract StakingFacetTest is DiamondTestSetup {
         assertEq(poolInfo2.lastRewardBlock, 11);
     }
 
+    function testStake_ShouldRevert_IfPoolHasZeroAllocationPoints() public {
+        // admin pool allocation points to 0
+        vm.startPrank(admin);
+        stakingFacet.updateStakingPool(
+            0, // pool id
+            0 // allocation points
+        );
+        vm.stopPrank();
+
+        vm.prank(user);
+        vm.expectRevert("Pool disabled");
+        stakingFacet.stake(0, 50 ether);
+    }
+
     function testStake_ShouldStakeTokens() public {
         // user stakes 50 STK
         vm.prank(user);
@@ -350,7 +364,7 @@ contract StakingFacetTest is DiamondTestSetup {
      * Step 1, admin creates 3 staking pools
      * - Pool 1: 100 allocation points
      * - Pool 2: 300 allocation points
-     * - Pool 3: 0 allocation points
+     * - Pool 3: 600 allocation points
      *
      * Step 2
      * - user stakes 50 STK in `Pool 1`
@@ -362,9 +376,9 @@ contract StakingFacetTest is DiamondTestSetup {
      * Step 4, users unstake half of the tokens
      *
      * Step 5, assert that:
-     * - user gets 2.5 reward tokens (25% pool allocation)
-     * - user2 gets 7.5 reward tokens (75% pool allocation)
-     * - user3 gets 0 reward tokens (0% pool allocation)
+     * - user gets 1 reward token (10% pool allocation)
+     * - user2 gets 3 reward tokens (30% pool allocation)
+     * - user3 gets 6 reward tokens (60% pool allocation)
      */
     function testUnstake_ShouldUnstakeTokens_WhenMultipleUsersUnstakeFromMultiplePools()
         public
@@ -379,7 +393,7 @@ contract StakingFacetTest is DiamondTestSetup {
             stakeToken
         );
         stakingFacet.createStakingPool(
-            0, // allocation points
+            600, // allocation points
             stakeToken
         );
         vm.stopPrank();
@@ -462,9 +476,9 @@ contract StakingFacetTest is DiamondTestSetup {
         userInfo = stakingFacet.getStakingUserInfo(0, user);
         poolInfo = stakingFacet.getStakingPoolInfo(0);
         assertEq(poolInfo.lastRewardBlock, 11);
-        assertEq(rewardToken.balanceOf(user), 2.5 ether);
+        assertEq(rewardToken.balanceOf(user), 1 ether);
         assertEq(userInfo.amount, 25 ether);
-        assertEq(userInfo.rewardDebt, 1.25 ether);
+        assertEq(userInfo.rewardDebt, 0.5 ether);
         assertEq(poolInfo.amount, 25 ether);
         assertEq(stakeToken.balanceOf(user), 75 ether);
 
@@ -472,9 +486,9 @@ contract StakingFacetTest is DiamondTestSetup {
         userInfo2 = stakingFacet.getStakingUserInfo(1, user2);
         poolInfo2 = stakingFacet.getStakingPoolInfo(1);
         assertEq(poolInfo2.lastRewardBlock, 11);
-        assertEq(rewardToken.balanceOf(user2), 7.5 ether);
+        assertEq(rewardToken.balanceOf(user2), 3 ether);
         assertEq(userInfo2.amount, 25 ether);
-        assertEq(userInfo2.rewardDebt, 3.75 ether);
+        assertEq(userInfo2.rewardDebt, 1.5 ether);
         assertEq(poolInfo2.amount, 25 ether);
         assertEq(stakeToken.balanceOf(user2), 75 ether);
 
@@ -482,9 +496,9 @@ contract StakingFacetTest is DiamondTestSetup {
         userInfo3 = stakingFacet.getStakingUserInfo(2, user3);
         poolInfo3 = stakingFacet.getStakingPoolInfo(2);
         assertEq(poolInfo3.lastRewardBlock, 11);
-        assertEq(rewardToken.balanceOf(user3), 0);
+        assertEq(rewardToken.balanceOf(user3), 6 ether);
         assertEq(userInfo3.amount, 25 ether);
-        assertEq(userInfo3.rewardDebt, 0);
+        assertEq(userInfo3.rewardDebt, 3 ether);
         assertEq(poolInfo3.amount, 25 ether);
         assertEq(stakeToken.balanceOf(user3), 75 ether);
     }


### PR DESCRIPTION
Resolves https://github.com/ubiquity/ubiquity-dollar/issues/1001

Depends on https://github.com/ubiquity/ubiquity-dollar/pull/1003

This PR fixes staking migration which was broken after changes in https://github.com/ubiquity/ubiquity-dollar/pull/999

How to QA production staking: https://gist.github.com/ryzhak/78ffabebeef6540b4e085c132df1d6a8

Note, [here](https://github.com/ryzhak/ubiquity-dollar/blob/d224f73d32e08a0be53cc8397df3daffd1487775/packages/contracts/migrations/mainnet/Deploy002_Staking.s.sol#L76) we set `block.number + 10` because foundry works pretty weird (at least the latest v1.3.5.). It seems it caches `block.number` at the beginning of the script and later (if there was a new block mined) [here](https://github.com/ryzhak/ubiquity-dollar/blob/d224f73d32e08a0be53cc8397df3daffd1487775/packages/contracts/migrations/mainnet/Deploy002_Staking.s.sol#L76) doesn't fetch the latest `block.number` but uses the cached one. Hence the error `Error: reverted with: Can't start in the past` occurs. Setting it to `block.number + 10` helps both for QA and production deploy in case a new block is mined somewhere in the middle of migration execution. Setting staking start time to `block.number + 10` simply delays staking start time for ~2 mins.
