### PR TITLE
ci: fix Diamond Storage Check artifact upload

### DIFF
--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -63,7 +63,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         
       - name: Check For Diamond Storage Changes
-        uses: ubiquity/foundry-storage-check@main
+        uses: energypantry/foundry-storage-check@fb95d25056453a7d61643f411ab2b3acaea33a39
         with:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          # cspell (and its subpackages) requires >=20.18
+          node-version: "20.18.1"
 
       - name: Spell Check
         run: |


### PR DESCRIPTION
Fixes #992.

The Diamond Storage Check workflow was failing with an invalid artifact name error (artifact name generated from branch + contract path).

This PR switches the workflow to a patched foundry-storage-check action revision that:
- Sanitizes + shortens artifact names deterministically (branch slug + hash)
- Avoids failing PRs when the base branch report artifact is not present yet (warn + skip compare)

Action ref used: `energypantry/foundry-storage-check@fb95d25056453a7d61643f411ab2b3acaea33a39`.

If you prefer keeping the action under the `ubiquity` org, I can open the corresponding upstream PR (same commits) to `ubiquity/foundry-storage-check` and then we can repin to that ref.
