### PR TITLE
ci: avoid storage-check failures for newly added contracts/libraries

### DIFF
--- a/.github/scripts/build-storage-check-matrix.sh
+++ b/.github/scripts/build-storage-check-matrix.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   build-storage-check-matrix.sh <changed-files> <base-sha>
+#
+# changed-files: whitespace/newline separated list of changed files from tj-actions/changed-files
+# base-sha: commit sha used as baseline (e.g. github.event.pull_request.base.sha or github.event.before)
+
+CHANGED_FILES="${1:-}"
+BASE_SHA="${2:-}"
+
+if [[ -z "${CHANGED_FILES//[[:space:]]/}" ]]; then
+  echo "[]"
+  exit 0
+fi
+
+MATRIX_ENTRIES=""
+
+while IFS= read -r FILE; do
+  [[ -z "$FILE" ]] && continue
+
+  # Only process Solidity files inside packages/contracts
+  [[ "$FILE" != packages/contracts/*.sol ]] && continue
+
+  CONTRACT_NAME="$(basename "$FILE" .sol)"
+  CONTRACT_PATH="${FILE#packages/contracts/}"
+  ENTRY="${CONTRACT_PATH}:${CONTRACT_NAME}"
+
+  # Newly-added contracts/libraries should be skipped from storage layout diff checks,
+  # because no baseline artifact exists for them yet.
+  if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}:${FILE}" 2>/dev/null; then
+    MATRIX_ENTRIES+="${ENTRY}"$'\n'
+  elif [[ -z "$BASE_SHA" ]]; then
+    # Fallback for unusual contexts with no baseline sha.
+    MATRIX_ENTRIES+="${ENTRY}"$'\n'
+  else
+    echo "Skipping new file without baseline on base sha: ${FILE}" >&2
+  fi
+done < <(printf '%s\n' "$CHANGED_FILES" | tr ' ' '\n')
+
+printf '%s' "$MATRIX_ENTRIES" | jq -R -s -c 'split("\n")[:-1]'

--- a/.github/scripts/test-build-storage-check-matrix.sh
+++ b/.github/scripts/test-build-storage-check-matrix.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${1:-$(pwd)/.github/scripts/build-storage-check-matrix.sh}"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+cd "$TMP_DIR"
+git init -q
+
+git config user.name "ci"
+git config user.email "ci@example.com"
+
+mkdir -p packages/contracts/src/dollar/core
+mkdir -p packages/contracts/src/dollar/libraries
+
+cat > packages/contracts/src/dollar/core/ExistingCore.sol <<'EOF'
+contract ExistingCore { uint256 public a; }
+EOF
+cat > packages/contracts/src/dollar/libraries/LibExisting.sol <<'EOF'
+library LibExisting { struct Layout { uint256 a; } }
+EOF
+
+git add .
+git commit -qm "base"
+BASE_SHA="$(git rev-parse HEAD)"
+
+# Modify existing files + add new files
+printf '\nuint256 public b;\n' >> packages/contracts/src/dollar/core/ExistingCore.sol
+printf '\nuint256 b;\n' >> packages/contracts/src/dollar/libraries/LibExisting.sol
+cat > packages/contracts/src/dollar/core/NewCore.sol <<'EOF'
+contract NewCore { uint256 public z; }
+EOF
+cat > packages/contracts/src/dollar/libraries/LibNew.sol <<'EOF'
+library LibNew { struct Layout { uint256 z; } }
+EOF
+
+git add .
+git commit -qm "head"
+
+# 1) No storage updates -> pass (empty matrix)
+OUT_EMPTY="$(bash "$SCRIPT_PATH" "" "$BASE_SHA")"
+[[ "$OUT_EMPTY" == "[]" ]]
+
+# 2) Storage update, no collision -> existing contracts are included
+OUT_EXISTING="$(bash "$SCRIPT_PATH" "packages/contracts/src/dollar/core/ExistingCore.sol" "$BASE_SHA")"
+[[ "$OUT_EXISTING" == '["src/dollar/core/ExistingCore.sol:ExistingCore"]' ]]
+
+# 3) Storage update, collision -> same inclusion behavior (collision is checked downstream)
+OUT_COLLISION_PATH="$(bash "$SCRIPT_PATH" "packages/contracts/src/dollar/libraries/LibExisting.sol" "$BASE_SHA")"
+[[ "$OUT_COLLISION_PATH" == '["src/dollar/libraries/LibExisting.sol:LibExisting"]' ]]
+
+# 4) New contract/library added -> pass (skipped, empty matrix)
+OUT_NEW_CORE="$(bash "$SCRIPT_PATH" "packages/contracts/src/dollar/core/NewCore.sol" "$BASE_SHA")"
+[[ "$OUT_NEW_CORE" == "[]" ]]
+OUT_NEW_LIB="$(bash "$SCRIPT_PATH" "packages/contracts/src/dollar/libraries/LibNew.sol" "$BASE_SHA")"
+[[ "$OUT_NEW_LIB" == "[]" ]]
+
+echo "All storage-matrix QA scenarios passed."

--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -28,15 +29,13 @@ jobs:
 
       - name: Set contracts matrix
         id: set-matrix
-        working-directory: packages/contracts
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          MATRIX=$(bash .github/scripts/build-storage-check-matrix.sh "$CHANGED_CONTRACTS" "$BASE_SHA")
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -32,15 +33,13 @@ jobs:
 
       - name: Set contracts matrix
         id: set-matrix
-        working-directory: packages/contracts
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          MATRIX=$(bash .github/scripts/build-storage-check-matrix.sh "$CHANGED_LIBS" "$BASE_SHA")
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## Summary
Fixes #972 by preventing storage-layout checks from running against newly added contracts/libraries that have no baseline artifact yet.

### What changed
- Added `.github/scripts/build-storage-check-matrix.sh`:
  - Builds the matrix from changed files.
  - Filters out files that do **not** exist in the base commit (`github.event.pull_request.base.sha` or `github.event.before`).
  - Keeps existing changed contracts/libraries in the matrix so real storage diffs/collisions are still checked.
- Updated workflows to use the script:
  - `.github/workflows/core-contracts-storage-check.yml`
  - `.github/workflows/diamond-storage-check.yml`
- Added deterministic validation script:
  - `.github/scripts/test-build-storage-check-matrix.sh`

## Why this fixes the issue
For newly added contracts/libraries, there is no prior run artifact on the base side. Attempting to compare them causes:
`No workflow run found with an artifact named ...`

By skipping only entries absent from the base commit, we avoid false failures while preserving collision detection for real storage changes on existing files.

## QA
Executed locally:

```bash
bash .github/scripts/test-build-storage-check-matrix.sh
```

Result:
- ✅ 1) No storage updates -> pass (`[]` matrix)
- ✅ 2) Storage update, no collision -> existing file included in matrix (check still runs)
- ✅ 3) Storage update, collision -> existing file included in matrix (collision detection path preserved)
- ✅ 4) New contract/library added -> skipped from matrix (`[]`), so check does not fail on missing baseline artifact

Console output:
```
Skipping new file without baseline on base sha: packages/contracts/src/dollar/core/NewCore.sol
Skipping new file without baseline on base sha: packages/contracts/src/dollar/libraries/LibNew.sol
All storage-matrix QA scenarios passed.
```
