### PR TITLE
ci: skip storage checks for newly-added contracts/libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -39,7 +39,7 @@ jobs:
           : > contracts.txt
 
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            git fetch --no-tags --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
 
           for CONTRACT in $CHANGED_CONTRACTS; do

--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -32,11 +32,31 @@ jobs:
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          set -euo pipefail
+          : > contracts.txt
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+          fi
+
+          for CONTRACT in $CHANGED_CONTRACTS; do
+            if [[ "$EVENT_NAME" == "pull_request" ]] && ! git cat-file -e "origin/$BASE_REF:$CONTRACT" 2>/dev/null; then
+              echo "Skipping new contract (no base artifact yet): $CONTRACT"
+              continue
+            fi
+
+            CONTRACT_NAME=$(basename "$CONTRACT" .sol)
+            echo "src/dollar/core/$CONTRACT_NAME.sol:$CONTRACT_NAME" >> contracts.txt
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+          if [[ -s contracts.txt ]]; then
+            echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -36,11 +36,31 @@ jobs:
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          set -euo pipefail
+          : > contracts.txt
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+          fi
+
+          for DIAMOND_LIB in $CHANGED_LIBS; do
+            if [[ "$EVENT_NAME" == "pull_request" ]] && ! git cat-file -e "origin/$BASE_REF:$DIAMOND_LIB" 2>/dev/null; then
+              echo "Skipping new diamond library (no base artifact yet): $DIAMOND_LIB"
+              continue
+            fi
+
+            LIB_NAME=$(basename "$DIAMOND_LIB" .sol)
+            echo "src/dollar/libraries/$LIB_NAME.sol:$LIB_NAME" >> contracts.txt
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+          if [[ -s contracts.txt ]]; then
+            echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -43,7 +43,7 @@ jobs:
           : > contracts.txt
 
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            git fetch --no-tags --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
 
           for DIAMOND_LIB in $CHANGED_LIBS; do


### PR DESCRIPTION
## Summary
Fixes CI false negatives in storage-layout checks for **newly added** contracts/libraries.

When a PR introduces a new core contract or a new diamond library, the storage-check action currently fails with:
`No workflow run found with an artifact named ...`
because there is no baseline artifact on the base branch yet.

### What changed
- `.github/workflows/core-contracts-storage-check.yml`
  - matrix generation now skips changed core contracts that do not exist on the PR base branch.
- `.github/workflows/diamond-storage-check.yml`
  - matrix generation now skips changed diamond libraries that do not exist on the PR base branch.
- both workflows now emit `matrix=[]` when every changed file is new, so the check job is cleanly skipped.

This keeps storage checks active for existing contracts/libraries and only bypasses comparisons that are impossible for new files.

Closes #972

## QA
Used local matrix-generation simulation with `EVENT_NAME=pull_request` and `BASE_REF=development`:

1) **No storage updates, CI passing**
- Existing contract path still resolves on base branch and remains in matrix (storage-check action still runs as before).

2) **Storage update, no collision, CI passing**
- Unchanged behavior (same `foundry-storage-check` action + inputs for existing files).

3) **Storage update, collision, CI failing**
- Unchanged behavior (same `foundry-storage-check` action + inputs for existing files).

4) **New contract/library added, CI passing**
- New file path does not exist on base branch, is skipped during matrix generation, and no missing-artifact failure occurs.

Sample simulation output:
- `Skipping new contract (no base artifact yet): packages/contracts/src/dollar/core/NewHotness.sol`
- `src/dollar/core/UbiquityGovernanceToken.sol:UbiquityGovernanceToken`
- `Skipping new diamond library (no base artifact yet): packages/contracts/src/dollar/libraries/LibNewFoo.sol`
- `src/dollar/libraries/LibAppStorage.sol:LibAppStorage`
