### PR TITLE
fix(ci): skip storage checks for newly added contracts/libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -26,17 +26,47 @@ jobs:
             contracts:
               - packages/contracts/src/dollar/core/*.sol
 
-      - name: Set contracts matrix
+      - name: Set contracts matrix (excluding new contracts)
         id: set-matrix
         working-directory: packages/contracts
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          BASE_BRANCH: ${{ github.base_ref || 'development' }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          set -euo pipefail
+          echo "Changed contracts: '$CHANGED_CONTRACTS'"
+          echo "Base branch: $BASE_BRANCH"
+
+          # Fetch base branch to check if contract existed before
+          git fetch origin $BASE_BRANCH:base-branch 2>/dev/null || true
+
+          : > contracts.txt
+          for CONTRACT in $CHANGED_CONTRACTS; do
+            # Trim whitespace
+            CONTRACT=$(echo "$CONTRACT" | tr -d '[:space:]')
+            if [ -z "$CONTRACT" ]; then
+              continue
+            fi
+            CONTRACT_NAME=$(basename "$CONTRACT" .sol)
+            SRC_PATH="src/dollar/core/${CONTRACT_NAME}.sol"
+
+            # Check if contract file existed in base branch
+            if git show "base-branch:${SRC_PATH}" >/dev/null 2>&1; then
+              echo "Existing contract changed: ${SRC_PATH}"
+              echo "${SRC_PATH}:${CONTRACT_NAME}" >> contracts.txt
+            else
+              echo "New contract (skipping storage check): ${SRC_PATH}"
+            fi
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+          # Set matrix only if there are existing contracts to check
+          if [ -f contracts.txt ] && [ -s contracts.txt ]; then
+            echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+            echo "No existing contracts changed (new contracts excluded from storage check)"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -57,11 +87,10 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+
       - name: Check For Core Contracts Storage Changes
         uses: Rubilmax/foundry-storage-check@main
         with:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}
           failOnRemoval: true
-          

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -30,17 +30,42 @@ jobs:
             libraries:
               - packages/contracts/src/dollar/libraries/Lib*.sol
 
-      - name: Set contracts matrix
+      - name: Set contracts matrix (excluding new libraries)
         id: set-matrix
         working-directory: packages/contracts
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          BASE_BRANCH: ${{ github.base_ref || 'development' }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          set -euo pipefail
+          echo "Changed libraries: $CHANGED_LIBS"
+          echo "Base branch: $BASE_BRANCH"
+
+          # Fetch base branch to check if library existed before
+          git fetch origin $BASE_BRANCH:base-branch 2>/dev/null || true
+
+          : > contracts.txt
+          for DIAMOND_LIB in $CHANGED_LIBS; do
+            LIB_NAME=$(echo "$DIAMOND_LIB" | xargs basename -a | cut -d'.' -f1)
+            SRC_PATH="src/dollar/libraries/${LIB_NAME}.sol"
+
+            # Check if library file existed in base branch
+            if git show "base-branch:${SRC_PATH}" >/dev/null 2>&1; then
+              echo "Existing library changed: ${SRC_PATH}"
+              echo "${SRC_PATH}:${LIB_NAME}" >> contracts.txt
+            else
+              echo "New library (skipping storage check): ${SRC_PATH}"
+            fi
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+          # Set matrix only if there are existing libraries to check
+          if [ -f contracts.txt ] && [ -s contracts.txt ]; then
+            echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+            echo "No existing libraries changed (new libraries excluded from storage check)"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -61,7 +86,7 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+
       - name: Check For Diamond Storage Changes
         uses: ubiquity/foundry-storage-check@main
         with:


### PR DESCRIPTION
Fixes #972

Skip storage layout checks when a contract or library is new (did not exist in the base branch). New contracts do not have an existing storage artifact, so checking them always fails.

Changes:
- Both workflow files now fetch the base branch and use `git show base-branch:<path>` to verify the file existed before running the storage check
- Only contracts/libraries that existed in the base branch are included in the CI matrix