### PR TITLE
fix(ci): skip storage checks for newly added contracts and libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -39,7 +39,7 @@ jobs:
           : > contracts.txt
 
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            git fetch --no-tags --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
 
           for CONTRACT in $CHANGED_CONTRACTS; do

--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -32,11 +32,31 @@ jobs:
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          set -euo pipefail
+          : > contracts.txt
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+          fi
+
+          for CONTRACT in $CHANGED_CONTRACTS; do
+            if [[ "$EVENT_NAME" == "pull_request" ]] && ! git cat-file -e "origin/$BASE_REF:$CONTRACT" 2>/dev/null; then
+              echo "Skipping new contract (no base artifact yet): $CONTRACT"
+              continue
+            fi
+
+            CONTRACT_NAME=$(basename "$CONTRACT" .sol)
+            echo "src/dollar/core/$CONTRACT_NAME.sol:$CONTRACT_NAME" >> contracts.txt
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+          if [[ -s contracts.txt ]]; then
+            echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -36,11 +36,31 @@ jobs:
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          set -euo pipefail
+          : > contracts.txt
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+          fi
+
+          for DIAMOND_LIB in $CHANGED_LIBS; do
+            if [[ "$EVENT_NAME" == "pull_request" ]] && ! git cat-file -e "origin/$BASE_REF:$DIAMOND_LIB" 2>/dev/null; then
+              echo "Skipping new diamond library (no base artifact yet): $DIAMOND_LIB"
+              continue
+            fi
+
+            LIB_NAME=$(basename "$DIAMOND_LIB" .sol)
+            echo "src/dollar/libraries/$LIB_NAME.sol:$LIB_NAME" >> contracts.txt
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+          if [[ -s contracts.txt ]]; then
+            echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -43,7 +43,7 @@ jobs:
           : > contracts.txt
 
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            git fetch --no-tags --depth=1 origin "refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
 
           for DIAMOND_LIB in $CHANGED_LIBS; do


### PR DESCRIPTION
Fixes #972

## Summary
Skip storage layout checks for newly added contracts and libraries since they have no prior artifact.

## Changes
- core-contracts-storage-check.yml: Skip new contracts not present in base branch
- diamond-storage-check.yml: Skip new libraries not present in base branch

## QA Scenarios (from issue #972)
1. No storage updates, CI passing ✅
2. Storage update, no collision, CI passing
3. Storage update, collision, CI failing
4. New contract added, CI passing