### PR TITLE
fix(ci): skip storage check for newly added contracts/libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -32,11 +32,15 @@ jobs:
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          ADDED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_added_files }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          # Filter out newly added contracts (no prior artifact exists for storage comparison)
+          comm -23 <(echo "$CHANGED_CONTRACTS" | tr ' ' '\n' | grep -v '^$' | sort) \
+                   <(echo "$ADDED_CONTRACTS" | tr ' ' '\n' | grep -v '^$' | sort) | \
+            while read CONTRACT; do
+              echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+            done
+          echo "matrix=$(cat contracts.txt 2>/dev/null | jq -R -s -c 'split("\n")[:-1]' || echo '[]')" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -36,11 +36,15 @@ jobs:
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          ADDED_LIBS: ${{ steps.changed-libraries.outputs.libraries_added_files }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          # Filter out newly added libraries (no prior artifact exists for storage comparison)
+          comm -23 <(echo "$CHANGED_LIBS" | tr ' ' '\n' | grep -v '^$' | sort) \
+                   <(echo "$ADDED_LIBS" | tr ' ' '\n' | grep -v '^$' | sort) | \
+            while read DIAMOND_LIB; do
+              echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+            done
+          echo "matrix=$(cat contracts.txt 2>/dev/null | jq -R -s -c 'split("\n")[:-1]' || echo '[]')" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## Summary
Fixes `ubiquity/ubiquity-dollar#972` - the `core-contracts-storage-check` and `diamond-storage-check` CI workflows were failing when a PR added a new contract or library.

## Problem
When a PR adds a **new contract** or **new library**, the storage check workflow fails with:
```
No workflow run found with an artifact named...
```
This happens because `foundry-storage-check` needs a previous storage layout artifact to compare against, and new contracts don't have one.

## Solution
Use `tj-actions/changed-files` `added_files` output to exclude newly added files from the storage check matrix. Use `comm -23` to subtract added files from all changed files, producing a matrix that only contains pre-existing contracts that were modified.

Fixed both workflows:
- `.github/workflows/core-contracts-storage-check.yml`
- `.github/workflows/diamond-storage-check.yml`

## QA Scenarios
| Scenario | Behavior |
|---|---|
| 1. No storage updates (no core/lib files changed) | `contracts_any_changed == false` → matrix empty → CI skipped → PASS |
| 2. Storage update, no collision (existing contract modified) | Added to matrix → check runs → PASS |
| 3. Storage update, collision (breaking change to existing) | Added to matrix → check runs → FAIL |
| 4. New contract added | Excluded from matrix via `comm -23` → CI skipped → PASS |

## Previous attempt
PR #1013 was closed - its approach (fetching base branch + `git show`) had path issues (repo-root vs working-directory). This approach is simpler and avoids that problem.

Closes #972