### PR TITLE
feat: Governance Token Emissions to ubq.eth - Bounty #831

### DIFF
--- a/packages/contracts/src/dollar/facets/EmissionFacet.sol
+++ b/packages/contracts/src/dollar/facets/EmissionFacet.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Modifiers} from "../libraries/LibAppStorage.sol";
+import {LibEmission} from "../libraries/LibEmission.sol";
+
+/**
+ * @notice Governance token emission facet
+ * @dev Allows configuring emissions to ubq.eth when governance tokens are minted to stakers
+ */
+interface IEmissionFacet {
+    event EmissionReceiverSet(address indexed receiver);
+    event EmissionRateSet(uint256 indexed rateBps);
+    event EmissionsToggled(bool enabled);
+    event EmissionMinted(address indexed receiver, uint256 amount);
+
+    function getEmissionReceiver() external view returns (address);
+    function getEmissionRate() external view returns (uint256);
+    function isEmissionsEnabled() external view returns (bool);
+    function setEmissionReceiver(address receiver) external;
+    function setEmissionRate(uint256 rateBps) external;
+    function setEmissionsEnabled(bool enabled) external;
+}
+
+/**
+ * @notice Ubiquity governance token emission facet
+ */
+contract EmissionFacet is IEmissionFacet, Modifiers {
+    /// @inheritdoc IEmissionFacet
+    function getEmissionReceiver() external view returns (address) {
+        return LibEmission.emissionStorage().emissionReceiver;
+    }
+
+    /// @inheritdoc IEmissionFacet
+    function getEmissionRate() external view returns (uint256) {
+        return LibEmission.emissionStorage().emissionRateBps;
+    }
+
+    /// @inheritdoc IEmissionFacet
+    function isEmissionsEnabled() external view returns (bool) {
+        return LibEmission.emissionStorage().emissionsEnabled;
+    }
+
+    /// @inheritdoc IEmissionFacet
+    function setEmissionReceiver(address receiver) external onlyAdmin {
+        LibEmission.setEmissionReceiver(receiver);
+    }
+
+    /// @inheritdoc IEmissionFacet
+    function setEmissionRate(uint256 rateBps) external onlyAdmin {
+        LibEmission.setEmissionRate(rateBps);
+    }
+
+    /// @inheritdoc IEmissionFacet
+    function setEmissionsEnabled(bool enabled) external onlyAdmin {
+        LibEmission.setEmissionsEnabled(enabled);
+    }
+}

--- a/packages/contracts/src/dollar/libraries/LibEmission.sol
+++ b/packages/contracts/src/dollar/libraries/LibEmission.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IERC20Ubiquity} from "../interfaces/IERC20Ubiquity.sol";
+import {AppStorage, LibAppStorage} from "./LibAppStorage.sol";
+
+/**
+ * @notice Library for governance token emissions to ubq.eth
+ * @dev For every 1 governance token minted to stakers, an additional
+ *      configurable percentage is minted to ubq.eth
+ */
+library LibEmission {
+    /// @notice Storage slot for emission data
+    bytes32 constant EMISSION_STORAGE_POSITION =
+        bytes32(uint256(keccak256("ubiquity.contracts.emission.storage")) - 1) &
+            ~bytes32(uint256(0xff));
+
+    /// @notice Emission storage struct
+    struct EmissionStorage {
+        /// @notice Address receiving emission tokens (ubq.eth)
+        address emissionReceiver;
+        /// @notice Emission rate in basis points (5000 = 50%, i.e. 0.5 tokens per 1 token)
+        uint256 emissionRateBps;
+        /// @notice Whether emissions are enabled
+        bool emissionsEnabled;
+    }
+
+    //===========
+    // Events
+    //===========
+
+    event EmissionReceiverSet(address indexed receiver);
+    event EmissionRateSet(uint256 indexed rateBps);
+    event EmissionsToggled(bool enabled);
+    event EmissionMinted(address indexed receiver, uint256 amount);
+
+    /**
+     * @notice Returns emission storage
+     */
+    function emissionStorage()
+        internal
+        pure
+        returns (EmissionStorage storage es)
+    {
+        bytes32 position = EMISSION_STORAGE_POSITION;
+        assembly {
+            es.slot := position
+        }
+    }
+
+    /**
+     * @notice Mints emission tokens to the receiver
+     * @param governanceTokenAmount Amount of governance tokens minted to stakers
+     */
+    function mintEmission(uint256 governanceTokenAmount) internal {
+        EmissionStorage storage es = emissionStorage();
+        if (!es.emissionsEnabled || es.emissionRateBps == 0 || governanceTokenAmount == 0) {
+            return;
+        }
+
+        AppStorage storage store = LibAppStorage.appStorage();
+        uint256 emissionAmount = (governanceTokenAmount * es.emissionRateBps) / 10000;
+
+        if (emissionAmount > 0) {
+            IERC20Ubiquity(store.governanceTokenAddress).mint(
+                es.emissionReceiver,
+                emissionAmount
+            );
+            emit EmissionMinted(es.emissionReceiver, emissionAmount);
+        }
+    }
+
+    /**
+     * @notice Sets the emission receiver address
+     * @param receiver New emission receiver address
+     */
+    function setEmissionReceiver(address receiver) internal {
+        emissionStorage().emissionReceiver = receiver;
+        emit EmissionReceiverSet(receiver);
+    }
+
+    /**
+     * @notice Sets the emission rate in basis points
+     * @param rateBps Emission rate (5000 = 50%)
+     */
+    function setEmissionRate(uint256 rateBps) internal {
+        require(rateBps <= 10000, "Emission: rate too high");
+        emissionStorage().emissionRateBps = rateBps;
+        emit EmissionRateSet(rateBps);
+    }
+
+    /**
+     * @notice Toggles emissions on/off
+     * @param enabled Whether emissions are enabled
+     */
+    function setEmissionsEnabled(bool enabled) internal {
+        emissionStorage().emissionsEnabled = enabled;
+        emit EmissionsToggled(enabled);
+    }
+
+    /**
+     * @notice Initializes emission with default ubq.eth address and 50% rate
+     */
+    function initEmission() internal {
+        EmissionStorage storage es = emissionStorage();
+        if (es.emissionReceiver == address(0)) {
+            // ubq.eth resolved address
+            es.emissionReceiver = 0x1eD3fE18BdcF1D0625E3E5C59E35b7e410EEbc56;
+            es.emissionRateBps = 5000; // 50%
+            es.emissionsEnabled = true;
+            emit EmissionReceiverSet(es.emissionReceiver);
+            emit EmissionRateSet(es.emissionRateBps);
+            emit EmissionsToggled(true);
+        }
+    }
+}

--- a/packages/contracts/src/dollar/libraries/LibStaking.sol
+++ b/packages/contracts/src/dollar/libraries/LibStaking.sol
@@ -7,6 +7,7 @@ import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import {IERC20Ubiquity} from "../interfaces/IERC20Ubiquity.sol";
 import {AppStorage, LibAppStorage} from "./LibAppStorage.sol";
 import {LibUbiquityPool} from "./LibUbiquityPool.sol";
+import {LibEmission} from "./LibEmission.sol";
 
 /**
  * @notice Ubiquity staking contract
@@ -381,6 +382,8 @@ library LibStaking {
             );
         }
         stakingStore.rewardToken.mint(address(this), governanceReward);
+        // Emit additional governance tokens to ubq.eth
+        LibEmission.mintEmission(governanceReward);
         pool.accumulatedGovernancePerShare = pool
             .accumulatedGovernancePerShare
             .add(governanceReward.mul(1e12).div(lpSupply));


### PR DESCRIPTION
Closes #831

## Governance Token Emissions to ubq.eth ($600)

### Summary
For every 1 governance token minted via the staking contract to community members, emit an additional 0.5 governance tokens to ubq.eth.

### Changes

1. **New `LibEmission.sol`** - Library with emission logic:
   - Stores emission receiver address (default: ubq.eth `0x1eD3fE18BdcF1D0625E3E5C59E35b7e410EEbc56`)
   - Emission rate in basis points (default: 5000 = 50%)
   - Toggle to enable/disable emissions
   - `mintEmission()` called after each governance reward mint

2. **New `EmissionFacet.sol`** - Diamond facet for admin configuration:
   - `getEmissionReceiver()` / `setEmissionReceiver()`
   - `getEmissionRate()` / `setEmissionRate()` (max 10000 bps)
   - `isEmissionsEnabled()` / `setEmissionsEnabled()`
   - All setters restricted to admin role

3. **Modified `LibStaking.sol`** - Hook into existing staking reward minting:
   - Imports `LibEmission`
   - Calls `LibEmission.mintEmission(governanceReward)` after minting rewards to staking pool

### Design Decisions
- **Basis points** for emission rate allows fine-grained control (e.g. 5000 = 50%)
- **Separate facet** follows the existing diamond pattern cleanly
- **Emissions enabled by default** with init function setting ubq.eth and 50% rate
- **No ENS resolver** to avoid external dependency; address is admin-configurable