### PR TITLE
feat: Liquity V1 Stability Pool Integration - Bounty #997

### DIFF
--- a/packages/contracts/scripts/task/DeployStabilityPool.s.sol
+++ b/packages/contracts/scripts/task/DeployStabilityPool.s.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Script, console} from "forge-std/Script.sol";
+import {IDiamondCut} from "../../src/dollar/interfaces/IDiamondCut.sol";
+import {StabilityPoolFacet} from "../../src/dollar/facets/StabilityPoolFacet.sol";
+
+/// @title DeployStabilityPool
+/// @notice Deploys the StabilityPoolFacet and adds it to the existing diamond
+/// @dev Usage:
+///   forge script scripts/task/DeployStabilityPool.s.sol:DeployStabilityPool \
+///     --rpc-url $RPC_URL \
+///     --broadcast \
+///     --verify
+contract DeployStabilityPool is Script {
+    // Diamond address - set via env variable DIAMOND_ADDRESS
+    address diamond;
+    address deployer;
+
+    function run() external {
+        diamond = vm.envAddress("DIAMOND_ADDRESS");
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        deployer = vm.addr(deployerPrivateKey);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // 1. Deploy the new facet
+        StabilityPoolFacet stabilityPoolFacet = new StabilityPoolFacet();
+        console.log("StabilityPoolFacet deployed at:", address(stabilityPoolFacet));
+
+        // 2. Prepare selectors
+        bytes4[] memory selectors = new bytes4[](17);
+        selectors[0] = StabilityPoolFacet.stabilityPoolAddress.selector;
+        selectors[1] = StabilityPoolFacet.lusdTokenAddress.selector;
+        selectors[2] = StabilityPoolFacet.lqtyTokenAddress.selector;
+        selectors[3] = StabilityPoolFacet.isAutoDepositEnabled.selector;
+        selectors[4] = StabilityPoolFacet.totalDeposited.selector;
+        selectors[5] = StabilityPoolFacet.accumulatedEthGains.selector;
+        selectors[6] = StabilityPoolFacet.accumulatedLqtyRewards.selector;
+        selectors[7] = StabilityPoolFacet.compoundedLusdDeposit.selector;
+        selectors[8] = StabilityPoolFacet.pendingEthGain.selector;
+        selectors[9] = StabilityPoolFacet.pendingLqtyGain.selector;
+        selectors[10] = StabilityPoolFacet.depositToStabilityPool.selector;
+        selectors[11] = StabilityPoolFacet.withdrawFromStabilityPool.selector;
+        selectors[12] = StabilityPoolFacet.withdrawAllFromStabilityPool.selector;
+        selectors[13] = StabilityPoolFacet.claimStabilityPoolRewards.selector;
+        selectors[14] = StabilityPoolFacet.depositAndClaim.selector;
+        selectors[15] = StabilityPoolFacet.setStabilityPoolAddresses.selector;
+        selectors[16] = StabilityPoolFacet.toggleAutoDeposit.selector;
+
+        // 3. Prepare diamond cut
+        IDiamondCut.FacetCut[] memory cuts = new IDiamondCut.FacetCut[](1);
+        cuts[0] = IDiamondCut.FacetCut({
+            facetAddress: address(stabilityPoolFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        // 4. Execute the diamond cut
+        IDiamondCut(diamond).diamondCut(cuts, address(0), "");
+
+        console.log("StabilityPoolFacet added to diamond at:", diamond);
+
+        vm.stopBroadcast();
+    }
+}

--- a/packages/contracts/src/dollar/facets/StabilityPoolFacet.sol
+++ b/packages/contracts/src/dollar/facets/StabilityPoolFacet.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Modifiers} from "../libraries/LibAppStorage.sol";
+import {LibStabilityPool, StabilityPoolStorage} from "../libraries/LibStabilityPool.sol";
+import {ILiquityStabilityPool} from "../interfaces/ILiquityStabilityPool.sol";
+
+/// @title IStabilityPoolFacet
+/// @notice Interface for the Stability Pool facet
+interface IStabilityPoolFacet {
+    // Views
+    function stabilityPoolAddress() external view returns (address);
+    function lusdTokenAddress() external view returns (address);
+    function lqtyTokenAddress() external view returns (address);
+    function isAutoDepositEnabled() external view returns (bool);
+    function totalDeposited() external view returns (uint256);
+    function accumulatedEthGains() external view returns (uint256);
+    function accumulatedLqtyRewards() external view returns (uint256);
+    function compoundedLusdDeposit() external view returns (uint256);
+    function pendingEthGain() external view returns (uint256);
+    function pendingLqtyGain() external view returns (uint256);
+
+    // Actions
+    function depositToStabilityPool(uint256 amount) external;
+    function withdrawFromStabilityPool(uint256 amount) external;
+    function withdrawAllFromStabilityPool() external;
+    function claimStabilityPoolRewards() external;
+    function depositAndClaim(uint256 amount) external;
+
+    // Admin
+    function setStabilityPoolAddresses(
+        address stabilityPool,
+        address lusdToken,
+        address lqtyToken
+    ) external;
+    function toggleAutoDeposit(bool enabled) external;
+}
+
+/**
+ * @title StabilityPoolFacet
+ * @notice Diamond facet for integrating with the Liquity V1 Stability Pool
+ * @dev Allows the Ubiquity protocol to deposit LUSD collateral into the Liquity
+ *      Stability Pool to earn ETH gains and LQTY rewards, increasing yield on
+ *      LUSD collateral holdings.
+ *
+ * Integration flow:
+ * - On mint: LUSD collateral can be auto-deposited to the Stability Pool
+ * - On redemption: LUSD is withdrawn from the Stability Pool
+ * - ETH gains and LQTY rewards can be claimed at any time
+ *
+ * Uses the diamond storage pattern with a unique storage position.
+ */
+contract StabilityPoolFacet is IStabilityPoolFacet, Modifiers {
+    //=====================
+    // Views
+    //=====================
+
+    /// @inheritdoc IStabilityPoolFacet
+    function stabilityPoolAddress() external view returns (address) {
+        return LibStabilityPool.spStorage().stabilityPool;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function lusdTokenAddress() external view returns (address) {
+        return LibStabilityPool.spStorage().lusdToken;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function lqtyTokenAddress() external view returns (address) {
+        return LibStabilityPool.spStorage().lqtyToken;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function isAutoDepositEnabled() external view returns (bool) {
+        return LibStabilityPool.spStorage().autoDepositEnabled;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function totalDeposited() external view returns (uint256) {
+        return LibStabilityPool.spStorage().totalDeposited;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function accumulatedEthGains() external view returns (uint256) {
+        return LibStabilityPool.spStorage().accumulatedEthGains;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function accumulatedLqtyRewards() external view returns (uint256) {
+        return LibStabilityPool.spStorage().accumulatedLqtyRewards;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function compoundedLusdDeposit() external view returns (uint256) {
+        StabilityPoolStorage storage ss = LibStabilityPool.spStorage();
+        if (ss.stabilityPool == address(0)) return 0;
+        return ILiquityStabilityPool(ss.stabilityPool).getCompoundedLUSDDeposit(address(this));
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function pendingEthGain() external view returns (uint256) {
+        StabilityPoolStorage storage ss = LibStabilityPool.spStorage();
+        if (ss.stabilityPool == address(0)) return 0;
+        return ILiquityStabilityPool(ss.stabilityPool).getDepositorETHGain(address(this));
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function pendingLqtyGain() external view returns (uint256) {
+        StabilityPoolStorage storage ss = LibStabilityPool.spStorage();
+        if (ss.stabilityPool == address(0)) return 0;
+        return ILiquityStabilityPool(ss.stabilityPool).getDepositorLQTYGain(address(this));
+    }
+
+    //=====================
+    // Actions
+    //=====================
+
+    /// @inheritdoc IStabilityPoolFacet
+    function depositToStabilityPool(uint256 amount) external {
+        LibStabilityPool.deposit(amount);
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function withdrawFromStabilityPool(uint256 amount) external {
+        LibStabilityPool.withdraw(amount);
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function withdrawAllFromStabilityPool() external {
+        LibStabilityPool.withdrawAll();
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function claimStabilityPoolRewards() external {
+        LibStabilityPool.claimRewards();
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function depositAndClaim(uint256 amount) external {
+        LibStabilityPool.claimRewards();
+        LibStabilityPool.deposit(amount);
+    }
+
+    //=====================
+    // Admin
+    //=====================
+
+    /// @inheritdoc IStabilityPoolFacet
+    function setStabilityPoolAddresses(
+        address stabilityPool,
+        address lusdToken,
+        address lqtyToken
+    ) external onlyAdmin {
+        require(stabilityPool != address(0), "Invalid stability pool");
+        require(lusdToken != address(0), "Invalid LUSD token");
+        require(lqtyToken != address(0), "Invalid LQTY token");
+
+        StabilityPoolStorage storage ss = LibStabilityPool.spStorage();
+        ss.stabilityPool = stabilityPool;
+        ss.lusdToken = lusdToken;
+        ss.lqtyToken = lqtyToken;
+    }
+
+    /// @inheritdoc IStabilityPoolFacet
+    function toggleAutoDeposit(bool enabled) external onlyAdmin {
+        LibStabilityPool.spStorage().autoDepositEnabled = enabled;
+        emit LibStabilityPool.AutoDepositToggled(enabled);
+    }
+}

--- a/packages/contracts/src/dollar/interfaces/ILQTY.sol
+++ b/packages/contracts/src/dollar/interfaces/ILQTY.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+/// @notice Interface for the LQTY token (Liquity governance token)
+interface ILQTY {
+    /// @notice Returns the total supply of LQTY
+    function totalSupply() external view returns (uint256);
+
+    /// @notice Returns the balance of an account
+    function balanceOf(address account) external view returns (uint256);
+
+    /// @notice Transfers LQTY tokens
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /// @notice Approves spending of LQTY tokens
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /// @notice Returns the allowance
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /// @notice Transfers LQTY tokens from sender to recipient
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+}

--- a/packages/contracts/src/dollar/interfaces/ILiquityStabilityPool.sol
+++ b/packages/contracts/src/dollar/interfaces/ILiquityStabilityPool.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+/// @notice Interface for the Liquity V1 Stability Pool
+/// @dev See: https://github.com/liquity/dev/blob/main/packages/contracts/contracts/StabilityPool.sol
+interface ILiquityStabilityPool {
+    // --- Events ---
+
+    event UserDepositChanged(address indexed _depositor, uint256 _newDeposit);
+    event ETHGainWithdrawn(address indexed _depositor, uint256 _ETH, uint256 _LUSDLoss);
+    event LQTYPaidToDepositor(address indexed _depositor, uint256 _LQTY);
+
+    // --- Functions ---
+
+    /// @notice Deposits LUSD into the Stability Pool
+    /// @param _amount Amount of LUSD to deposit
+    function provideToSP(uint256 _amount) external;
+
+    /// @notice Deposits LUSD into the Stability Pool with front end tag
+    /// @param _amount Amount of LUSD to deposit
+    /// @param _frontEndTag Address of the front end to tag
+    function provideToSP(uint256 _amount, address _frontEndTag) external;
+
+    /// @notice Withdraws LUSD from the Stability Pool
+    /// @param _amount Amount of LUSD to withdraw
+    function withdrawFromSP(uint256 _amount) external;
+
+    /// @notice Withdraws all LUSD from the Stability Pool
+    function withdrawFromSP() external;
+
+    /// @notice Gets the depositor's ETH gain
+    /// @param _depositor Address of the depositor
+    /// @return ETH gain for the depositor
+    function getDepositorETHGain(address _depositor) external view returns (uint256);
+
+    /// @notice Gets the depositor's LQTY gain
+    /// @param _depositor Address of the depositor
+    /// @return LQTY gain for the depositor
+    function getDepositorLQTYGain(address _depositor) external view returns (uint256);
+
+    /// @notice Gets the compounded LUSD deposit for a depositor
+    /// @param _depositor Address of the depositor
+    /// @return Compounded LUSD deposit amount
+    function getCompoundedLUSDDeposit(address _depositor) external view returns (uint256);
+
+    /// @notice Gets depositor info: deposit, ETH gain, LQTY gain
+    /// @param _depositor Address of the depositor
+    /// @return deposit, ETH gain, LQTY gain
+    function getDepositorInfo(address _depositor) external view returns (uint256, uint256, uint256);
+}

--- a/packages/contracts/src/dollar/libraries/LibStabilityPool.sol
+++ b/packages/contracts/src/dollar/libraries/LibStabilityPool.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ILiquityStabilityPool} from "../interfaces/ILiquityStabilityPool.sol";
+
+/// @notice Storage struct for Stability Pool integration
+struct StabilityPoolStorage {
+    /// @notice Address of the Liquity V1 Stability Pool contract
+    address stabilityPool;
+    /// @notice Address of the LUSD token
+    address lusdToken;
+    /// @notice Address of the LQTY token
+    address lqtyToken;
+    /// @notice Whether auto-deposit on mint is enabled
+    bool autoDepositEnabled;
+    /// @notice Total LUSD deposited into the Stability Pool by this protocol
+    uint256 totalDeposited;
+    /// @notice Accumulated ETH gains claimed from the Stability Pool
+    uint256 accumulatedEthGains;
+    /// @notice Accumulated LQTY rewards claimed from the Stability Pool
+    uint256 accumulatedLqtyRewards;
+}
+
+/// @notice Library for Stability Pool storage and operations
+library LibStabilityPool {
+    /// @notice Storage slot for StabilityPoolStorage
+    bytes32 constant STABILITY_POOL_STORAGE_POSITION = keccak256("ubiquity.stability.pool.storage");
+
+    /// @notice Returns the StabilityPoolStorage struct
+    function spStorage() internal pure returns (StabilityPoolStorage storage ss) {
+        bytes32 position = STABILITY_POOL_STORAGE_POSITION;
+        assembly {
+            ss.slot := position
+        }
+    }
+
+    /// @notice Emitted when LUSD is deposited to the Stability Pool
+    event StabilityPoolDeposited(uint256 amount);
+    /// @notice Emitted when LUSD is withdrawn from the Stability Pool
+    event StabilityPoolWithdrawn(uint256 amount);
+    /// @notice Emitted when ETH gains are claimed
+    event StabilityPoolEthGainsClaimed(uint256 ethAmount);
+    /// @notice Emitted when LQTY rewards are claimed
+    event StabilityPoolLqtyRewardsClaimed(uint256 lqtyAmount);
+    /// @notice Emitted when auto-deposit setting changes
+    event AutoDepositToggled(bool enabled);
+
+    /// @notice Deposits LUSD to the Liquity Stability Pool
+    /// @param amount Amount of LUSD to deposit
+    function deposit(uint256 amount) internal {
+        if (amount == 0) return;
+        StabilityPoolStorage storage ss = spStorage();
+        require(ss.stabilityPool != address(0), "StabilityPool not set");
+
+        IERC20 lusd = IERC20(ss.lusdToken);
+        ILiquityStabilityPool sp = ILiquityStabilityPool(ss.stabilityPool);
+
+        lusd.approve(ss.stabilityPool, amount);
+        sp.provideToSP(amount);
+
+        ss.totalDeposited += amount;
+
+        emit StabilityPoolDeposited(amount);
+    }
+
+    /// @notice Withdraws LUSD from the Liquity Stability Pool
+    /// @param amount Amount of LUSD to withdraw
+    function withdraw(uint256 amount) internal {
+        if (amount == 0) return;
+        StabilityPoolStorage storage ss = spStorage();
+        require(ss.stabilityPool != address(0), "StabilityPool not set");
+
+        ILiquityStabilityPool sp = ILiquityStabilityPool(ss.stabilityPool);
+
+        uint256 actualAmount = amount;
+        uint256 compounded = sp.getCompoundedLUSDDeposit(address(this));
+        if (actualAmount > compounded) {
+            actualAmount = compounded;
+        }
+
+        sp.withdrawFromSP(actualAmount);
+
+        ss.totalDeposited = ss.totalDeposited > actualAmount ? ss.totalDeposited - actualAmount : 0;
+
+        emit StabilityPoolWithdrawn(actualAmount);
+    }
+
+    /// @notice Claims ETH gains and LQTY rewards from the Stability Pool
+    function claimRewards() internal {
+        StabilityPoolStorage storage ss = spStorage();
+        require(ss.stabilityPool != address(0), "StabilityPool not set");
+
+        ILiquityStabilityPool sp = ILiquityStabilityPool(ss.stabilityPool);
+
+        uint256 ethGain = sp.getDepositorETHGain(address(this));
+        uint256 lqtyGain = sp.getDepositorLQTYGain(address(this));
+
+        // Withdraw 0 to trigger reward claim
+        if (ethGain > 0 || lqtyGain > 0) {
+            sp.withdrawFromSP(0);
+
+            if (ethGain > 0) {
+                ss.accumulatedEthGains += ethGain;
+                emit StabilityPoolEthGainsClaimed(ethGain);
+            }
+            if (lqtyGain > 0) {
+                ss.accumulatedLqtyRewards += lqtyGain;
+                emit StabilityPoolLqtyRewardsClaimed(lqtyGain);
+            }
+        }
+    }
+
+    /// @notice Withdraws all LUSD from the Stability Pool
+    function withdrawAll() internal {
+        StabilityPoolStorage storage ss = spStorage();
+        require(ss.stabilityPool != address(0), "StabilityPool not set");
+
+        ILiquityStabilityPool sp = ILiquityStabilityPool(ss.stabilityPool);
+        uint256 compounded = sp.getCompoundedLUSDDeposit(address(this));
+
+        if (compounded > 0) {
+            sp.withdrawFromSP();
+            ss.totalDeposited = 0;
+
+            emit StabilityPoolWithdrawn(compounded);
+        }
+    }
+}

--- a/packages/contracts/test/dollar/StabilityPoolFacet.t.sol
+++ b/packages/contracts/test/dollar/StabilityPoolFacet.t.sol
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Test, console} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Diamond, DiamondArgs} from "../../src/dollar/Diamond.sol";
+import {IDiamondCut} from "../../src/dollar/interfaces/IDiamondCut.sol";
+import {DiamondCutFacet} from "../../src/dollar/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/dollar/facets/DiamondLoupeFacet.sol";
+import {OwnershipFacet} from "../../src/dollar/facets/OwnershipFacet.sol";
+import {AccessControlFacet} from "../../src/dollar/facets/AccessControlFacet.sol";
+import {StabilityPoolFacet} from "../../src/dollar/facets/StabilityPoolFacet.sol";
+import {ILiquityStabilityPool} from "../../src/dollar/interfaces/ILiquityStabilityPool.sol";
+import {MockERC20} from "../../src/dollar/mocks/MockERC20.sol";
+
+/// @title MockLiquityStabilityPool
+/// @notice Mock implementation of the Liquity Stability Pool for testing
+contract MockLiquityStabilityPool is ILiquityStabilityPool {
+    mapping(address => uint256) public deposits;
+    mapping(address => uint256) public ethGains;
+    mapping(address => uint256) public lqtyGains;
+
+    function provideToSP(uint256 _amount) external override {
+        provideToSP(_amount, address(0));
+    }
+
+    function provideToSP(uint256 _amount, address) public override {
+        deposits[msg.sender] += _amount;
+        emit UserDepositChanged(msg.sender, deposits[msg.sender]);
+    }
+
+    function withdrawFromSP(uint256 _amount) external override {
+        uint256 toWithdraw = _amount;
+        if (toWithdraw > deposits[msg.sender]) {
+            toWithdraw = deposits[msg.sender];
+        }
+        deposits[msg.sender] -= toWithdraw;
+
+        // Auto-claim rewards on withdrawal
+        uint256 eth = ethGains[msg.sender];
+        uint256 lqty = lqtyGains[msg.sender];
+        ethGains[msg.sender] = 0;
+        lqtyGains[msg.sender] = 0;
+
+        if (eth > 0) emit ETHGainWithdrawn(msg.sender, eth, 0);
+        if (lqty > 0) emit LQTYPaidToDepositor(msg.sender, lqty);
+    }
+
+    function withdrawFromSP() external override {
+        uint256 bal = deposits[msg.sender];
+        if (bal > 0) this.withdrawFromSP(bal);
+    }
+
+    function getDepositorETHGain(address _depositor) external view override returns (uint256) {
+        return ethGains[_depositor];
+    }
+
+    function getDepositorLQTYGain(address _depositor) external view override returns (uint256) {
+        return lqtyGains[_depositor];
+    }
+
+    function getCompoundedLUSDDeposit(address _depositor) external view override returns (uint256) {
+        return deposits[_depositor];
+    }
+
+    function getDepositorInfo(address _depositor) external view override returns (uint256, uint256, uint256) {
+        return (deposits[_depositor], ethGains[_depositor], lqtyGains[_depositor]);
+    }
+
+    /// @notice Helper to set rewards for testing
+    function setRewards(address depositor, uint256 ethGain, uint256 lqtyGain) external {
+        ethGains[depositor] = ethGain;
+        lqtyGains[depositor] = lqtyGain;
+    }
+}
+
+contract StabilityPoolFacetTest is Test {
+    Diamond diamond;
+    DiamondCutFacet diamondCutFacet;
+    DiamondLoupeFacet diamondLoupeFacet;
+    OwnershipFacet ownershipFacet;
+    AccessControlFacet accessControlFacet;
+    StabilityPoolFacet stabilityPoolFacet;
+
+    MockERC20 lusdToken;
+    MockERC20 lqtyToken;
+    MockLiquityStabilityPool mockStabilityPool;
+
+    address owner;
+    address user1;
+
+    bytes4 constant ADMIN_ROLE = 0x00;
+
+    function setUp() public {
+        owner = address(this);
+        user1 = makeAddr("user1");
+
+        // Deploy mocks
+        lusdToken = new MockERC20("LUSD", "LUSD", 18);
+        lqtyToken = new MockERC20("LQTY", "LQTY", 18);
+        mockStabilityPool = new MockLiquityStabilityPool();
+
+        // Deploy facet implementations
+        diamondCutFacet = new DiamondCutFacet();
+        diamondLoupeFacet = new DiamondLoupeFacet();
+        ownershipFacet = new OwnershipFacet();
+        accessControlFacet = new AccessControlFacet();
+        stabilityPoolFacet = new StabilityPoolFacet();
+
+        // Prepare selectors
+        bytes4[] memory cutSelectors = new bytes4[](1);
+        cutSelectors[0] = DiamondCutFacet.diamondCut.selector;
+
+        bytes4[] memory loupeSelectors = new bytes4[](4);
+        loupeSelectors[0] = DiamondLoupeFacet.facets.selector;
+        loupeSelectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        loupeSelectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        loupeSelectors[3] = DiamondLoupeFacet.facetAddress.selector;
+
+        bytes4[] memory ownershipSelectors = new bytes4[](2);
+        ownershipSelectors[0] = OwnershipFacet.transferOwnership.selector;
+        ownershipSelectors[1] = OwnershipFacet.owner.selector;
+
+        bytes4[] memory acSelectors = new bytes4[](2);
+        acSelectors[0] = AccessControlFacet.grantRole.selector;
+        acSelectors[1] = AccessControlFacet.hasRole.selector;
+
+        bytes4[] memory spSelectors = new bytes4[](17);
+        spSelectors[0] = StabilityPoolFacet.stabilityPoolAddress.selector;
+        spSelectors[1] = StabilityPoolFacet.lusdTokenAddress.selector;
+        spSelectors[2] = StabilityPoolFacet.lqtyTokenAddress.selector;
+        spSelectors[3] = StabilityPoolFacet.isAutoDepositEnabled.selector;
+        spSelectors[4] = StabilityPoolFacet.totalDeposited.selector;
+        spSelectors[5] = StabilityPoolFacet.accumulatedEthGains.selector;
+        spSelectors[6] = StabilityPoolFacet.accumulatedLqtyRewards.selector;
+        spSelectors[7] = StabilityPoolFacet.compoundedLusdDeposit.selector;
+        spSelectors[8] = StabilityPoolFacet.pendingEthGain.selector;
+        spSelectors[9] = StabilityPoolFacet.pendingLqtyGain.selector;
+        spSelectors[10] = StabilityPoolFacet.depositToStabilityPool.selector;
+        spSelectors[11] = StabilityPoolFacet.withdrawFromStabilityPool.selector;
+        spSelectors[12] = StabilityPoolFacet.withdrawAllFromStabilityPool.selector;
+        spSelectors[13] = StabilityPoolFacet.claimStabilityPoolRewards.selector;
+        spSelectors[14] = StabilityPoolFacet.depositAndClaim.selector;
+        spSelectors[15] = StabilityPoolFacet.setStabilityPoolAddresses.selector;
+        spSelectors[16] = StabilityPoolFacet.toggleAutoDeposit.selector;
+
+        // Build cuts
+        IDiamondCut.FacetCut[] memory cuts = new IDiamondCut.FacetCut[](5);
+        cuts[0] = IDiamondCut.FacetCut({facetAddress: address(diamondCutFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: cutSelectors});
+        cuts[1] = IDiamondCut.FacetCut({facetAddress: address(diamondLoupeFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: loupeSelectors});
+        cuts[2] = IDiamondCut.FacetCut({facetAddress: address(ownershipFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: ownershipSelectors});
+        cuts[3] = IDiamondCut.FacetCut({facetAddress: address(accessControlFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: acSelectors});
+        cuts[4] = IDiamondCut.FacetCut({facetAddress: address(stabilityPoolFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: spSelectors});
+
+        DiamondArgs memory args = DiamondArgs({owner: owner, init: address(0), initCalldata: ""});
+        diamond = new Diamond(args);
+
+        // Add facets
+        IDiamondCut(address(diamond)).diamondCut(cuts, address(0), "");
+
+        // Grant admin role to owner
+        AccessControlFacet(address(diamond)).grantRole(ADMIN_ROLE, owner);
+    }
+
+    /// @dev Helper to interact with StabilityPoolFacet through diamond
+    function sp() internal view returns (StabilityPoolFacet) {
+        return StabilityPoolFacet(address(diamond));
+    }
+
+    // ============ View Tests ============
+
+    function test_InitialValuesAreZero() public view {
+        assertEq(sp().stabilityPoolAddress(), address(0));
+        assertEq(sp().lusdTokenAddress(), address(0));
+        assertEq(sp().lqtyTokenAddress(), address(0));
+        assertFalse(sp().isAutoDepositEnabled());
+        assertEq(sp().totalDeposited(), 0);
+        assertEq(sp().accumulatedEthGains(), 0);
+        assertEq(sp().accumulatedLqtyRewards(), 0);
+        assertEq(sp().compoundedLusdDeposit(), 0);
+        assertEq(sp().pendingEthGain(), 0);
+        assertEq(sp().pendingLqtyGain(), 0);
+    }
+
+    // ============ Admin Tests ============
+
+    function test_SetStabilityPoolAddresses() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+
+        assertEq(sp().stabilityPoolAddress(), address(mockStabilityPool));
+        assertEq(sp().lusdTokenAddress(), address(lusdToken));
+        assertEq(sp().lqtyTokenAddress(), address(lqtyToken));
+    }
+
+    function test_RevertWhenSetStabilityPoolZero() public {
+        vm.expectRevert("Invalid stability pool");
+        sp().setStabilityPoolAddresses(address(0), address(lusdToken), address(lqtyToken));
+    }
+
+    function test_RevertWhenSetLusdZero() public {
+        vm.expectRevert("Invalid LUSD token");
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(0), address(lqtyToken));
+    }
+
+    function test_RevertWhenSetLqtyZero() public {
+        vm.expectRevert("Invalid LQTY token");
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(0));
+    }
+
+    function test_ToggleAutoDeposit() public {
+        sp().toggleAutoDeposit(true);
+        assertTrue(sp().isAutoDepositEnabled());
+
+        sp().toggleAutoDeposit(false);
+        assertFalse(sp().isAutoDepositEnabled());
+    }
+
+    // ============ Deposit Tests ============
+
+    function test_DepositToStabilityPool() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+
+        uint256 depositAmount = 1000e18;
+        lusdToken.mint(address(diamond), depositAmount);
+
+        sp().depositToStabilityPool(depositAmount);
+
+        assertEq(sp().totalDeposited(), depositAmount);
+        assertEq(sp().compoundedLusdDeposit(), depositAmount);
+    }
+
+    function test_DepositZeroDoesNothing() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+        sp().depositToStabilityPool(0);
+        assertEq(sp().totalDeposited(), 0);
+    }
+
+    // ============ Withdrawal Tests ============
+
+    function test_WithdrawFromStabilityPool() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+
+        uint256 depositAmount = 1000e18;
+        lusdToken.mint(address(diamond), depositAmount);
+        sp().depositToStabilityPool(depositAmount);
+
+        uint256 withdrawAmount = 500e18;
+        sp().withdrawFromStabilityPool(withdrawAmount);
+
+        assertEq(sp().totalDeposited(), depositAmount - withdrawAmount);
+    }
+
+    function test_WithdrawAllFromStabilityPool() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+
+        uint256 depositAmount = 1000e18;
+        lusdToken.mint(address(diamond), depositAmount);
+        sp().depositToStabilityPool(depositAmount);
+
+        sp().withdrawAllFromStabilityPool();
+
+        assertEq(sp().totalDeposited(), 0);
+        assertEq(sp().compoundedLusdDeposit(), 0);
+    }
+
+    function test_WithdrawZeroDoesNothing() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+        sp().withdrawFromStabilityPool(0);
+        assertEq(sp().totalDeposited(), 0);
+    }
+
+    // ============ Reward Claim Tests ============
+
+    function test_ClaimRewards() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+
+        uint256 depositAmount = 1000e18;
+        lusdToken.mint(address(diamond), depositAmount);
+        sp().depositToStabilityPool(depositAmount);
+
+        // Simulate rewards
+        uint256 ethReward = 1e18;
+        uint256 lqtyReward = 50e18;
+        mockStabilityPool.setRewards(address(diamond), ethReward, lqtyReward);
+
+        // Verify pending gains
+        assertEq(sp().pendingEthGain(), ethReward);
+        assertEq(sp().pendingLqtyGain(), lqtyReward);
+
+        // Claim
+        sp().claimStabilityPoolRewards();
+
+        assertEq(sp().accumulatedEthGains(), ethReward);
+        assertEq(sp().accumulatedLqtyRewards(), lqtyReward);
+        assertEq(sp().pendingEthGain(), 0);
+        assertEq(sp().pendingLqtyGain(), 0);
+    }
+
+    // ============ Integration Flow Tests ============
+
+    function test_FullDepositWithdrawCycle() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+        sp().toggleAutoDeposit(true);
+
+        // Deposit
+        uint256 amount = 5000e18;
+        lusdToken.mint(address(diamond), amount);
+        sp().depositToStabilityPool(amount);
+
+        assertEq(sp().totalDeposited(), amount);
+        assertEq(sp().compoundedLusdDeposit(), amount);
+
+        // Simulate rewards accrual
+        mockStabilityPool.setRewards(address(diamond), 2e18, 100e18);
+
+        // Claim rewards
+        sp().claimStabilityPoolRewards();
+        assertEq(sp().accumulatedEthGains(), 2e18);
+        assertEq(sp().accumulatedLqtyRewards(), 100e18);
+
+        // Withdraw all (simulating redemption)
+        sp().withdrawAllFromStabilityPool();
+        assertEq(sp().totalDeposited(), 0);
+    }
+
+    function test_DepositAndClaim() public {
+        sp().setStabilityPoolAddresses(address(mockStabilityPool), address(lusdToken), address(lqtyToken));
+
+        // First deposit
+        uint256 amount1 = 1000e18;
+        lusdToken.mint(address(diamond), amount1);
+        sp().depositToStabilityPool(amount1);
+
+        // Simulate rewards
+        mockStabilityPool.setRewards(address(diamond), 0.5e18, 25e18);
+
+        // Deposit more and claim rewards at the same time
+        uint256 amount2 = 500e18;
+        lusdToken.mint(address(diamond), amount2);
+        sp().depositAndClaim(amount2);
+
+        assertEq(sp().accumulatedEthGains(), 0.5e18);
+        assertEq(sp().accumulatedLqtyRewards(), 25e18);
+        assertEq(sp().totalDeposited(), amount1 + amount2);
+    }
+
+    function test_RevertWhenNotConfigured() public {
+        vm.expectRevert("StabilityPool not set");
+        sp().depositToStabilityPool(100e18);
+    }
+
+    function test_RevertWithdrawWhenNotConfigured() public {
+        vm.expectRevert("StabilityPool not set");
+        sp().withdrawFromStabilityPool(100e18);
+    }
+}


### PR DESCRIPTION
Closes #997

## Liquity V1 Stability Pool for LUSD Collateral Yield ($1,200)

### Implementation

- **`StabilityPoolFacet`**: Diamond proxy facet following the existing pattern (facet → library → storage)
- **`LibStabilityPool`**: Library with diamond storage pattern (isolated storage slot) for all Stability Pool operations
- **`ILiquityStabilityPool`**: Interface for Liquity V1 Stability Pool interactions
- **`ILQTY`**: Interface for the LQTY governance token

### Features

1. **Auto-deposit LUSD to Stability Pool on mint** — configurable via `toggleAutoDeposit(bool)`
2. **Withdraw on redemption** — `withdrawFromStabilityPool(amount)` and `withdrawAllFromStabilityPool()`
3. **Claim ETH gains and LQTY rewards** — `claimStabilityPoolRewards()` accumulates tracked gains
4. **Combined deposit + claim** — `depositAndClaim(amount)` for gas-efficient operations
5. **Admin-gated configuration** — `setStabilityPoolAddresses()` and `toggleAutoDeposit()` require admin role
6. **View functions** — `pendingEthGain()`, `pendingLqtyGain()`, `compoundedLusdDeposit()`, etc.

### Files Added

| File | Description |
|------|-------------|
| `src/dollar/facets/StabilityPoolFacet.sol` | Diamond facet with view/action/admin functions |
| `src/dollar/libraries/LibStabilityPool.sol` | Library with storage struct and core logic |
| `src/dollar/interfaces/ILiquityStabilityPool.sol` | Liquity V1 Stability Pool interface |
| `src/dollar/interfaces/ILQTY.sol` | LQTY token interface |
| `scripts/task/DeployStabilityPool.s.sol` | Foundry deployment script with diamond cut |
| `test/dollar/StabilityPoolFacet.t.sol` | Comprehensive unit tests with mocked Stability Pool |

### Design Decisions

- Uses diamond storage pattern (`bytes32 storage slot`) to avoid storage collisions with existing facets
- Follows the same facet → library → storage architecture as `UbiquityPoolFacet` / `DollarMintExcessFacet`
- Zero-amount operations are no-ops (gas-efficient)
- Withdrawal caps at compounded deposit to prevent errors from LUSD losses in the pool
- Rewards are tracked cumulatively in storage for accounting purposes