### PR TITLE
fix(ci): skip storage check for newly added contracts and libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -47,6 +47,7 @@ jobs:
     if: ${{ needs.provide_contracts.outputs.matrix != '[]' && needs.provide_contracts.outputs.matrix != '' }}
 
     strategy:
+      fail-fast: false
       matrix:
         contract: ${{ fromJSON(needs.provide_contracts.outputs.matrix) }}
 
@@ -57,11 +58,38 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+
+      - name: Check if contract exists on base branch
+        id: check-existing
+        run: |
+          CONTRACT_PATH="${{ matrix.contract }}"
+          # Extract the file path part (before the colon)
+          FILE_PATH="${CONTRACT_PATH%%:*}"
+          FULL_PATH="packages/contracts/${FILE_PATH}"
+
+          BASE_REF="${{ github.base_ref || github.ref_name }}"
+
+          # Fetch the base branch to check if the file exists there
+          git fetch origin "${BASE_REF}" --depth=1 2>/dev/null || true
+
+          if git cat-file -e "origin/${BASE_REF}:${FULL_PATH}" 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Contract ${FILE_PATH} exists on ${BASE_REF}, will check storage layout"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Contract ${FILE_PATH} is newly added (not on ${BASE_REF}), skipping storage layout check"
+          fi
+
       - name: Check For Core Contracts Storage Changes
+        if: steps.check-existing.outputs.exists == 'true'
         uses: Rubilmax/foundry-storage-check@main
         with:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}
           failOnRemoval: true
-          
+
+      - name: Skip storage check for new contract
+        if: steps.check-existing.outputs.exists == 'false'
+        run: |
+          echo "::notice::Skipping storage layout check for newly added contract ${{ matrix.contract }}"
+          echo "New contracts have no prior storage layout to compare against."

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -51,6 +51,7 @@ jobs:
     if: ${{ needs.provide_contracts.outputs.matrix != '[]' && needs.provide_contracts.outputs.matrix != '' }}
 
     strategy:
+      fail-fast: false
       matrix:
         contract: ${{ fromJSON(needs.provide_contracts.outputs.matrix) }}
 
@@ -61,11 +62,39 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+
+      - name: Check if library exists on base branch
+        id: check-existing
+        run: |
+          CONTRACT_PATH="${{ matrix.contract }}"
+          # Extract the file path part (before the colon)
+          FILE_PATH="${CONTRACT_PATH%%:*}"
+          FULL_PATH="packages/contracts/${FILE_PATH}"
+
+          BASE_REF="${{ github.base_ref || github.ref_name }}"
+
+          # Fetch the base branch to check if the file exists there
+          git fetch origin "${BASE_REF}" --depth=1 2>/dev/null || true
+
+          if git cat-file -e "origin/${BASE_REF}:${FULL_PATH}" 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Library ${FILE_PATH} exists on ${BASE_REF}, will check storage layout"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Library ${FILE_PATH} is newly added (not on ${BASE_REF}), skipping storage layout check"
+          fi
+
       - name: Check For Diamond Storage Changes
+        if: steps.check-existing.outputs.exists == 'true'
         uses: ubiquity/foundry-storage-check@main
         with:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}
           failOnRemoval: true
           failOnLabelDiff: true
+
+      - name: Skip storage check for new library
+        if: steps.check-existing.outputs.exists == 'false'
+        run: |
+          echo "::notice::Skipping storage layout check for newly added library ${{ matrix.contract }}"
+          echo "New libraries have no prior storage layout to compare against."


### PR DESCRIPTION
Closes #972

## Problem

The `core-contracts-storage-check` and `diamond-storage-check` workflows fail with `"No workflow run found with an artifact named..."` when a **new contract/library** is added. The `foundry-storage-check` action searches for a baseline artifact from the base branch, but newly added contracts have no prior storage layout artifact to compare against.

## Solution

Added a **pre-check step** that determines whether the contract/library file exists on the base branch (`github.base_ref`):

1. **Fetch base branch** and check if the contract file exists using `git cat-file`
2. **Existing contracts** → run `foundry-storage-check` as before (normal storage comparison)
3. **New contracts** → skip with `::notice::` annotation (no baseline exists, no collision possible)
4. **`fail-fast: false`** — ensures one new contract does not cancel checks for other existing contracts in the matrix

## Changes

- `.github/workflows/core-contracts-storage-check.yml` — Added `check-existing` step + conditional execution + `fail-fast: false`
- `.github/workflows/diamond-storage-check.yml` — Same fix for diamond libraries

## QA Scenarios

| Scenario | Expected Result |
|---|---|
| No storage updates | ✅ CI passes (no contracts in matrix) |
| Storage update, no collision | ✅ CI passes (foundry-storage-check compares against baseline) |
| Storage update, collision | ❌ CI fails (foundry-storage-check detects collision) |
| New contract added | ✅ CI passes (skipped with notice, no baseline exists) |