### PR TITLE
fix(ci): skip storage check for newly added contracts/libraries

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -32,11 +32,15 @@ jobs:
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          ADDED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_added_files }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          # Filter out newly added contracts (no prior artifact exists for storage comparison)
+          comm -23 <(echo "$CHANGED_CONTRACTS" | tr ' ' '\n' | grep -v '^$' | sort) \
+                   <(echo "$ADDED_CONTRACTS" | tr ' ' '\n' | grep -v '^$' | sort) | \
+            while read CONTRACT; do
+              echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+            done
+          echo "matrix=$(cat contracts.txt 2>/dev/null | jq -R -s -c 'split("\n")[:-1]' || echo '[]')" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -36,11 +36,15 @@ jobs:
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          ADDED_LIBS: ${{ steps.changed-libraries.outputs.libraries_added_files }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
-          done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          # Filter out newly added libraries (no prior artifact exists for storage comparison)
+          comm -23 <(echo "$CHANGED_LIBS" | tr ' ' '\n' | grep -v '^$' | sort) \
+                   <(echo "$ADDED_LIBS" | tr ' ' '\n' | grep -v '^$' | sort) | \
+            while read DIAMOND_LIB; do
+              echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+            done
+          echo "matrix=$(cat contracts.txt 2>/dev/null | jq -R -s -c 'split("\n")[:-1]' || echo '[]')" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## Summary

Fixes `core-contracts-storage-check` and `diamond-storage-check` workflows failing when a new contract is added.

### Problem
When a new contract is added, the storage layout check fails with:
`No workflow run found with an artifact named...`

This is because `foundry-storage-check` tries to compare the new contract's storage against a previous artifact that doesn't exist for new contracts.

### Solution
Use `tj-actions/changed-files` `added_files` output to detect newly added contracts, then use `comm -23` to subtract them from the changed files list. Only pre-existing modified contracts enter the storage check matrix.

## Testing
- New contracts: skip storage check (no prior artifact needed)
- Modified existing contracts: run storage check as before  
- Unchanged contracts: not in matrix (no action taken)

Closes #972

---
/claim #972