### PR TITLE
fix: skip storage checks for new contracts

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -32,11 +33,21 @@ jobs:
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          touch contracts.txt
+
+          for CONTRACT in $CHANGED_CONTRACTS; do
+            if [ "$EVENT_NAME" = "pull_request" ] && ! git cat-file -e "${BASE_SHA}:${CONTRACT}" 2>/dev/null; then
+              echo "Skipping newly added contract without baseline storage artifact: ${CONTRACT}"
+              continue
+            fi
+
+            CONTRACT_NAME="$(basename "$CONTRACT" .sol)"
+            echo "src/dollar/core/${CONTRACT_NAME}.sol:${CONTRACT_NAME}" >> contracts.txt
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -51,7 +62,7 @@ jobs:
         contract: ${{ fromJSON(needs.provide_contracts.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -36,11 +37,21 @@ jobs:
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          touch contracts.txt
+
+          for DIAMOND_LIB in $CHANGED_LIBS; do
+            if [ "$EVENT_NAME" = "pull_request" ] && ! git cat-file -e "${BASE_SHA}:${DIAMOND_LIB}" 2>/dev/null; then
+              echo "Skipping newly added library without baseline storage artifact: ${DIAMOND_LIB}"
+              continue
+            fi
+
+            LIB_NAME="$(basename "$DIAMOND_LIB" .sol)"
+            echo "src/dollar/libraries/${LIB_NAME}.sol:${LIB_NAME}" >> contracts.txt
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -55,7 +66,7 @@ jobs:
         contract: ${{ fromJSON(needs.provide_contracts.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
This fixes #972 by keeping newly added contracts and libraries out of the storage-layout check matrix when there is no baseline artifact on the base branch.

The storage checks still run for modified existing contracts. For pull requests, the workflow now fetches enough history to inspect the base SHA and skips only files that do not exist there.

Tested locally with simulated changed-file inputs for:

- newly added core contracts
- modified existing core contracts
- newly added diamond libraries
- modified existing diamond libraries
- mixed new and existing files

I also validated the workflow syntax and confirmed the working tree only includes the two storage-check workflow updates.