### PR TITLE
fix(ci): skip storage checks for added contracts

### DIFF
--- a/.github/scripts/test-storage-check-workflows.py
+++ b/.github/scripts/test-storage-check-workflows.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+WORKFLOW_EXPECTATIONS = (
+    (
+        ".github/workflows/core-contracts-storage-check.yml",
+        "contracts_modified_files != ''",
+        "contracts_modified_files",
+        "contracts_all_changed_files",
+    ),
+    (
+        ".github/workflows/diamond-storage-check.yml",
+        "libraries_modified_files != ''",
+        "libraries_modified_files",
+        "libraries_all_changed_files",
+    ),
+)
+
+
+def main() -> int:
+    failures = []
+
+    for workflow_path, expected_gate, expected_files, forbidden_files in WORKFLOW_EXPECTATIONS:
+        text = (ROOT / workflow_path).read_text()
+
+        if expected_gate not in text:
+            failures.append(f"{workflow_path}: missing gate {expected_gate!r}")
+        if expected_files not in text:
+            failures.append(f"{workflow_path}: missing modified-file output {expected_files!r}")
+        if forbidden_files in text:
+            failures.append(f"{workflow_path}: still uses added-file-inclusive output {forbidden_files!r}")
+
+    if failures:
+        print("Storage workflow checks failed:")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print("Storage workflow checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Validate storage workflow filters
+        run: python3 .github/scripts/test-storage-check-workflows.py
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
@@ -29,9 +32,9 @@ jobs:
       - name: Set contracts matrix
         id: set-matrix
         working-directory: packages/contracts
-        if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
+        if: steps.changed-contracts.outputs.contracts_modified_files != ''
         env:
-          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_modified_files }}
         run: |
           for CONTRACT in "$CHANGED_CONTRACTS"; do
             echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Set contracts matrix
         id: set-matrix
         working-directory: packages/contracts
-        if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
+        if: steps.changed-libraries.outputs.libraries_modified_files != ''
         env:
-          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_modified_files }}
         run: |
           for DIAMOND_LIB in "$CHANGED_LIBS"; do
             echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt


### PR DESCRIPTION
Resolves #972

## Summary
- Build the storage-check matrices from `*_modified_files` instead of `*_all_changed_files`.
- Skip storage-check matrix generation when a PR only adds new core contracts or diamond libraries.
- Add a lightweight workflow validation script to prevent this regression from returning.

## Root cause
The storage-check workflows used added-file-inclusive changed-files outputs, so newly added contracts/libraries were passed to `foundry-storage-check` even though they do not have previous storage artifacts to compare against.

## QA
- `python3 .github/scripts/test-storage-check-workflows.py`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .github/workflows/core-contracts-storage-check.yml .github/workflows/diamond-storage-check.yml`
- `git diff --check HEAD~1 HEAD`
