### PR TITLE
ci: skip new files in storage checks

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -32,9 +32,18 @@ jobs:
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          ADDED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_added_files }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          : > contracts.txt
+
+          printf "%s\n" "$CHANGED_CONTRACTS" | tr ' ' '\n' | sed '/^$/d' | while read -r CONTRACT; do
+            if printf "%s\n" "$ADDED_CONTRACTS" | tr ' ' '\n' | grep -Fxq "$CONTRACT"; then
+              echo "Skipping ${CONTRACT}; newly added contracts do not have a baseline storage artifact yet."
+              continue
+            fi
+
+            CONTRACT_NAME="$(basename "$CONTRACT" .sol)"
+            echo "src/dollar/core/${CONTRACT_NAME}.sol:${CONTRACT_NAME}" >> contracts.txt
           done
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -36,9 +36,18 @@ jobs:
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          ADDED_LIBS: ${{ steps.changed-libraries.outputs.libraries_added_files }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          : > contracts.txt
+
+          printf "%s\n" "$CHANGED_LIBS" | tr ' ' '\n' | sed '/^$/d' | while read -r DIAMOND_LIB; do
+            if printf "%s\n" "$ADDED_LIBS" | tr ' ' '\n' | grep -Fxq "$DIAMOND_LIB"; then
+              echo "Skipping ${DIAMOND_LIB}; newly added libraries do not have a baseline storage artifact yet."
+              continue
+            fi
+
+            LIB_NAME="$(basename "$DIAMOND_LIB" .sol)"
+            echo "src/dollar/libraries/${LIB_NAME}.sol:${LIB_NAME}" >> contracts.txt
           done
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- skips newly added core contracts in the core storage layout matrix, since they do not have a baseline artifact yet
- applies the same new-file skip to newly added diamond libraries
- keeps existing changed contracts and libraries in the matrix so normal storage checks still run

Fixes #972

## Testing
- git diff --cached --check
- smoke-tested the matrix shell logic locally with one existing file and one newly added file; local Git Bash does not have jq, so the existing workflow jq command could not be executed locally