### PR TITLE
fix: skip storage check for new contracts/libraries (#972)

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -33,10 +34,25 @@ jobs:
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
         run: |
+          # Filter out contracts that are new (no existing storage snapshot)
           for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+            CONTRACT_NAME=$(echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1)
+            CONTRACT_PATH="src/dollar/core/${CONTRACT_NAME}.sol"
+            SNAPSHOT_PATH="storage-layouts/${CONTRACT_NAME}.json"
+            
+            if [ -f "$SNAPSHOT_PATH" ]; then
+              echo "Existing contract: ${CONTRACT_PATH}:${CONTRACT_NAME}"
+              echo "${CONTRACT_PATH}:${CONTRACT_NAME}" >> contracts.txt
+            else
+              echo "New contract (skipping storage check): ${CONTRACT_PATH}:${CONTRACT_NAME}"
+            fi
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          
+          if [ -f contracts.txt ]; then
+            echo "matrix=$(cat contracts.txt | jq -R -s -c 'split(\"\n\")[:-1]')" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -54,14 +70,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+      
       - name: Check For Core Contracts Storage Changes
         uses: Rubilmax/foundry-storage-check@main
         with:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}
           failOnRemoval: true
-          

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -37,10 +38,25 @@ jobs:
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
         run: |
+          # Filter out libraries that are new (no existing storage snapshot)
           for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+            LIB_NAME=$(echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1)
+            LIB_PATH="src/dollar/libraries/${LIB_NAME}.sol"
+            SNAPSHOT_PATH="storage-layouts/${LIB_NAME}.json"
+            
+            if [ -f "$SNAPSHOT_PATH" ]; then
+              echo "Existing library: ${LIB_PATH}:${LIB_NAME}"
+              echo "${LIB_PATH}:${LIB_NAME}" >> contracts.txt
+            else
+              echo "New library (skipping storage check): ${LIB_PATH}:${LIB_NAME}"
+            fi
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          
+          if [ -f contracts.txt ]; then
+            echo "matrix=$(cat contracts.txt | jq -R -s -c 'split(\"\n\")[:-1]')" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=[]" >> $GITHUB_OUTPUT
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -58,10 +74,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+      
       - name: Check For Diamond Storage Changes
         uses: ubiquity/foundry-storage-check@main
         with:


### PR DESCRIPTION
## Problem

When a new contract is added to the ubiquity-dollar project, the core-contracts-storage-check and diamond-storage-check CI workflows fail because there's no existing storage snapshot to compare against.

## Solution

Modified both workflows to check if each changed contract/library has an existing storage snapshot (storage-layouts/*.json). If not, it's a new contract and the storage check is skipped for that file.

## Changes

### core-contracts-storage-check.yml
- Added logic to filter out new contracts (those without existing storage snapshots)
- Added persist-credentials: false to checkout steps for security

### diamond-storage-check.yml
- Same logic applied to diamond libraries

## QA

1. No storage updates, CI passing
2. Storage update, no collision, CI passing
3. Storage update, collision, CI failing
4. New contract/library added, CI passing

Closes #972