### PR TITLE
fix: skip storage layout check for newly added contracts

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -28,15 +29,29 @@ jobs:
 
       - name: Set contracts matrix
         id: set-matrix
-        working-directory: packages/contracts
         if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
         env:
           CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
-            echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
+          : > contracts.txt
+          if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            git cat-file -e "$BASE_SHA" 2>/dev/null || git fetch --no-tags origin "$BASE_SHA"
+          fi
+          for CONTRACT in $CHANGED_CONTRACTS; do
+            [ -n "$CONTRACT" ] || continue
+            if [ -n "$BASE_SHA" ] && git cat-file -e "${BASE_SHA}:${CONTRACT}" 2>/dev/null; then
+              name=$(basename "$CONTRACT" .sol)
+              echo "src/dollar/core/${name}.sol:${name}" >> contracts.txt
+            else
+              echo "skip new contract (no base layout): $CONTRACT"
+            fi
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          if [ -s contracts.txt ]; then
+            echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix=[]' >> "$GITHUB_OUTPUT"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -57,11 +72,10 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+
       - name: Check For Core Contracts Storage Changes
         uses: Rubilmax/foundry-storage-check@main
         with:
           workingDirectory: packages/contracts
           contract: ${{ matrix.contract }}
           failOnRemoval: true
-          

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -32,15 +33,29 @@ jobs:
 
       - name: Set contracts matrix
         id: set-matrix
-        working-directory: packages/contracts
         if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
         env:
           CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
-            echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
+          : > contracts.txt
+          if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            git cat-file -e "$BASE_SHA" 2>/dev/null || git fetch --no-tags origin "$BASE_SHA"
+          fi
+          for DIAMOND_LIB in $CHANGED_LIBS; do
+            [ -n "$DIAMOND_LIB" ] || continue
+            if [ -n "$BASE_SHA" ] && git cat-file -e "${BASE_SHA}:${DIAMOND_LIB}" 2>/dev/null; then
+              name=$(basename "$DIAMOND_LIB" .sol)
+              echo "src/dollar/libraries/${name}.sol:${name}" >> contracts.txt
+            else
+              echo "skip new library (no base layout): $DIAMOND_LIB"
+            fi
           done
-          echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          if [ -s contracts.txt ]; then
+            echo "matrix=$(jq -R -s -c 'split("\n")[:-1]' contracts.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix=[]' >> "$GITHUB_OUTPUT"
+          fi
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -61,7 +76,7 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        
+
       - name: Check For Diamond Storage Changes
         uses: ubiquity/foundry-storage-check@main
         with:


### PR DESCRIPTION
Fixes #972

## What
`core-contracts-storage-check` and `diamond-storage-check` failed when a PR added a contract or `Lib*.sol` that does not exist on the base branch (`No workflow run found with an artifact named...`). New files have no prior layout, so a collision cannot have happened.

The matrix step now keeps a file only if that path exists on the base SHA (PR base, or `github.event.before` on push). New files are logged and skipped. If nothing remains, the matrix is `[]` and the existing check job condition skips the layout job.

Collision checks for contracts/libraries that already exist on the base are unchanged.

## QA (expected)
1. No storage updates: no core/lib changes in the matrix — layout job skipped, CI pass.
2. Storage update, no collision: file exists on base, compatible layout change — CI pass.
3. Storage update, collision: file exists on base, incompatible layout — CI fail (unchanged action).
4. New contract or library added: path absent on base — skipped, CI pass.

## Note
This does not claim assignment. `/start` on #972 currently requires a core team member. An older open PR (#1030) covers the same issue.