### PR TITLE
fix(ci): skip storage-layout check for newly added contracts

### DIFF
--- a/.github/workflows/core-contracts-storage-check.yml
+++ b/.github/workflows/core-contracts-storage-check.yml
@@ -29,11 +29,12 @@ jobs:
       - name: Set contracts matrix
         id: set-matrix
         working-directory: packages/contracts
-        if: steps.changed-contracts.outputs.contracts_any_changed == 'true'
+        # Skip newly added contracts (#972): only modified files have a baseline artifact.
+        if: steps.changed-contracts.outputs.contracts_any_modified == 'true'
         env:
-          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_changed_files }}
+          CHANGED_CONTRACTS: ${{ steps.changed-contracts.outputs.contracts_all_modified_files }}
         run: |
-          for CONTRACT in "$CHANGED_CONTRACTS"; do
+          for CONTRACT in $CHANGED_CONTRACTS; do
             echo ${CONTRACT} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/core/{}.sol:{} >> contracts.txt
           done
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT

--- a/.github/workflows/diamond-storage-check.yml
+++ b/.github/workflows/diamond-storage-check.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Set contracts matrix
         id: set-matrix
         working-directory: packages/contracts
-        if: steps.changed-libraries.outputs.libraries_any_changed == 'true'
+        # Skip newly added libraries (#972): only modified files have a baseline artifact.
+        if: steps.changed-libraries.outputs.libraries_any_modified == 'true'
         env:
-          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_changed_files }}
+          CHANGED_LIBS: ${{ steps.changed-libraries.outputs.libraries_all_modified_files }}
         run: |
-          for DIAMOND_LIB in "$CHANGED_LIBS"; do
+          for DIAMOND_LIB in $CHANGED_LIBS; do
             echo ${DIAMOND_LIB} | xargs basename -a | cut -d'.' -f1 | xargs -I{} echo src/dollar/libraries/{}.sol:{} >> contracts.txt
           done
           echo "matrix=$(cat contracts.txt | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Fixes #972

When a **new** core contract or diamond `Lib*.sol` is added, `core-contracts-storage-check` / `diamond-storage-check` fail looking for a baseline artifact that cannot exist yet.

## Change
- Use `tj-actions/changed-files` `*_all_modified_files` / `*_any_modified` instead of `*_all_changed_files` / `*_any_changed` in both workflows.
- Newly **added** files drop out of the matrix; **modified** existing files still run collision checks.
- Tiny loop fix: iterate space-separated paths correctly.

Two files only. Targets `development`. Unrelated to oversized PR #1030.

## QA (issue checklist)
| Scenario | Expected |
|---|---|
| 1) No storage updates | Pass (empty / no matrix) |
| 2) Storage update, no collision | Pass (modified file checked) |
| 3) Storage update, collision | Fail (checker detects collision) |
| 4) New contract/library added | Pass (added file skipped — no missing artifact) |

## Notes
- `/wallet` registered for clawdiu; `/start` currently blocked by Priority-1 collaborator gate — submitting draft PR per DevPool tip.